### PR TITLE
Fix/subtour drop

### DIFF
--- a/app/Http/Resources/TourResource.php
+++ b/app/Http/Resources/TourResource.php
@@ -22,25 +22,29 @@ class TourResource extends JsonResource
             'position' => $this->position,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
-            'markers' => $this->markers->map(function ($marker) {
-                return [
-                    'id' => $marker->id,
-                    'name' => $marker->name,
-                    'lat' => $marker->lat,
-                    'lng' => $marker->lng,
-                    'latitude' => $marker->lat, // For backward compatibility
-                    'longitude' => $marker->lng, // For backward compatibility
-                    'type' => $marker->type,
-                    'notes' => $marker->notes,
-                    'url' => $marker->url,
-                    'is_unesco' => $marker->is_unesco,
-                    'trip_id' => $marker->trip_id,
-                    'created_at' => $marker->created_at,
-                    'updated_at' => $marker->updated_at,
-                    'position' => $marker->pivot->position ?? 0,
-                ];
-            }),
-            'sub_tours' => TourResource::collection($this->whenLoaded('subTours')),
+            'markers' => $this->whenLoaded('markers', function () {
+                return $this->markers->map(function ($marker) {
+                    return [
+                        'id' => $marker->id,
+                        'name' => $marker->name,
+                        'lat' => $marker->lat,
+                        'lng' => $marker->lng,
+                        'latitude' => $marker->lat, // For backward compatibility
+                        'longitude' => $marker->lng, // For backward compatibility
+                        'type' => $marker->type,
+                        'notes' => $marker->notes,
+                        'url' => $marker->url,
+                        'is_unesco' => $marker->is_unesco,
+                        'trip_id' => $marker->trip_id,
+                        'created_at' => $marker->created_at,
+                        'updated_at' => $marker->updated_at,
+                        'position' => $marker->pivot->position ?? 0,
+                    ];
+                });
+            }, []),
+            'sub_tours' => $this->whenLoaded('subTours', function () {
+                return TourResource::collection($this->subTours);
+            }, []),
         ];
     }
 }

--- a/app/Http/Resources/TourResource.php
+++ b/app/Http/Resources/TourResource.php
@@ -14,6 +14,9 @@ class TourResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
+        // Ensure sub-tours have their markers loaded
+        $this->loadMissing('subTours.markers');
+
         return [
             'id' => $this->id,
             'name' => $this->name,
@@ -41,10 +44,10 @@ class TourResource extends JsonResource
                         'position' => $marker->pivot->position ?? 0,
                     ];
                 });
-            }, []),
+            }, collect()),
             'sub_tours' => $this->whenLoaded('subTours', function () {
                 return TourResource::collection($this->subTours);
-            }, []),
+            }, collect()),
         ];
     }
 }

--- a/resources/js/components/tour-panel.tsx
+++ b/resources/js/components/tour-panel.tsx
@@ -101,7 +101,8 @@ function SortableMarkerItem({ marker, index }: SortableMarkerItemProps) {
                         {marker.name || 'Unnamed Location'}
                     </div>
                     <div className="text-xs text-gray-600">
-                        {marker.lat.toFixed(6)}, {marker.lng.toFixed(6)}
+                        {(marker.lat ?? marker.latitude ?? 0).toFixed(6)},{' '}
+                        {(marker.lng ?? marker.longitude ?? 0).toFixed(6)}
                     </div>
                 </div>
                 <div className="flex items-center gap-1.5">
@@ -155,14 +156,8 @@ function SortableSubTourItem({
         },
     });
 
-    // Get markers for this sub-tour
-    const subTourMarkers = subTour.markers
-        ? subTour.markers
-              .map((tourMarker) =>
-                  markers.find((marker) => marker.id === tourMarker.id),
-              )
-              .filter((marker): marker is MarkerData => marker !== undefined)
-        : [];
+    // Get markers for this sub-tour - they come directly from the API with full data
+    const subTourMarkers = subTour.markers || [];
 
     return (
         <li

--- a/resources/js/components/travel-map.tsx
+++ b/resources/js/components/travel-map.tsx
@@ -1286,9 +1286,19 @@ export default function TravelMap({
             }
         }
 
-        // Check if dropped on a tour tab (adding marker to tour)
-        if (overId.startsWith('tour-')) {
-            const tourId = parseInt(overId.replace('tour-', ''));
+        // Check if dropped on a tour or sub-tour (adding marker to tour)
+        let tourId: number | null = null;
+        
+        // Check if dropped on a sub-tour item in mixed list
+        if (overId.startsWith('tour-item-subtour-')) {
+            tourId = parseInt(overId.replace('tour-item-subtour-', ''));
+        } 
+        // Check if dropped on a regular tour tab
+        else if (overId.startsWith('tour-') && !overId.startsWith('tour-item-')) {
+            tourId = parseInt(overId.replace('tour-', ''));
+        }
+
+        if (tourId !== null && !isNaN(tourId)) {
             const markerId = activeId;
 
             // Helper function to find a tour (including sub-tours)


### PR DESCRIPTION
This pull request improves the handling and consistency of tour and marker data throughout the backend API and frontend, especially when dealing with sub-tours and their markers. The changes ensure that marker and sub-tour relationships are always fully loaded and available in API responses, and that the frontend can reliably consume this data structure. Additionally, drag-and-drop logic for assigning markers to tours and sub-tours in the UI is enhanced for better user experience and correctness.

**Backend API and Resource Improvements:**

* Ensured that when returning a `TourResource` from the controller (especially after updates, attaching/detaching markers, or reordering), the related `markers` and all `subTours.markers` are always loaded, providing complete relationship data to the frontend (`TourController.php`). [[1]](diffhunk://#diff-36526a14e626e38a018d4944910dd289c7c3d2ebba9114e991b43ccd6e37081bL90-R91) [[2]](diffhunk://#diff-36526a14e626e38a018d4944910dd289c7c3d2ebba9114e991b43ccd6e37081bL124-R129) [[3]](diffhunk://#diff-36526a14e626e38a018d4944910dd289c7c3d2ebba9114e991b43ccd6e37081bR141-R143) [[4]](diffhunk://#diff-36526a14e626e38a018d4944910dd289c7c3d2ebba9114e991b43ccd6e37081bL164-R172)
* Updated the `TourResource` to always load `subTours.markers` if missing, and to use `whenLoaded` for both `markers` and `subTours` to avoid nulls and ensure collections are returned (`TourResource.php`). [[1]](diffhunk://#diff-73d3fd4d3772e9baa3bd41ca6d9366c41c8f12fca214e81f6dbfba70d587045fR17-R19) [[2]](diffhunk://#diff-73d3fd4d3772e9baa3bd41ca6d9366c41c8f12fca214e81f6dbfba70d587045fL25-R29) [[3]](diffhunk://#diff-73d3fd4d3772e9baa3bd41ca6d9366c41c8f12fca214e81f6dbfba70d587045fL42-R50)

**Frontend Data Handling and UI Logic:**

* Simplified how sub-tour markers are accessed in the UI, now relying directly on the API to provide full marker data for sub-tours (`tour-panel.tsx`).
* Improved marker coordinate display logic to handle both `lat`/`lng` and `latitude`/`longitude` field names for better compatibility (`tour-panel.tsx`).

**Drag-and-Drop and Marker Assignment Logic:**

* Enhanced drag-and-drop logic in the map component to support assigning markers to tours and sub-tours by dropping them on any relevant item (marker or sub-tour) within a tour, and clarified the logic for detecting drop targets (`travel-map.tsx`). [[1]](diffhunk://#diff-05bb05215c31d145d620a53158d164265e69528b930c1d7c876c516671589eefR1050-R1102) [[2]](diffhunk://#diff-05bb05215c31d145d620a53158d164265e69528b930c1d7c876c516671589eefL1289-R1355)
* Improved error handling and debugging output for marker assignment failures in the frontend (`travel-map.tsx`).

These changes collectively ensure that the frontend always receives complete and consistent data for tours, sub-tours, and markers, and that drag-and-drop interactions for managing these relationships are more robust and user-friendly.