### PR TITLE
Phase 3: Mobile Draggable Bottom Sheets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
                 "clsx": "^2.1.1",
                 "concurrently": "^9.0.1",
                 "easymde": "^2.20.0",
+                "framer-motion": "^12.34.0",
                 "globals": "^15.14.0",
                 "i18next": "^25.8.0",
                 "i18next-browser-languagedetector": "^8.2.0",
@@ -5721,6 +5722,33 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/framer-motion": {
+            "version": "12.34.0",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.0.tgz",
+            "integrity": "sha512-+/H49owhzkzQyxtn7nZeF4kdH++I2FWrESQ184Zbcw5cEqNHYkE5yxWxcTLSj5lNx3NWdbIRy5FHqUvetD8FWg==",
+            "license": "MIT",
+            "dependencies": {
+                "motion-dom": "^12.34.0",
+                "motion-utils": "^12.29.2",
+                "tslib": "^2.4.0"
+            },
+            "peerDependencies": {
+                "@emotion/is-prop-valid": "*",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/is-prop-valid": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/fromentries": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
@@ -7442,6 +7470,21 @@
             "engines": {
                 "node": ">= 18"
             }
+        },
+        "node_modules/motion-dom": {
+            "version": "12.34.0",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.0.tgz",
+            "integrity": "sha512-Lql3NuEcScRDxTAO6GgUsRHBZOWI/3fnMlkMcH5NftzcN37zJta+bpbMAV9px4Nj057TuvRooMK7QrzMCgtz6Q==",
+            "license": "MIT",
+            "dependencies": {
+                "motion-utils": "^12.29.2"
+            }
+        },
+        "node_modules/motion-utils": {
+            "version": "12.29.2",
+            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
+            "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
+            "license": "MIT"
         },
         "node_modules/ms": {
             "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
         "easymde": "^2.20.0",
+        "framer-motion": "^12.34.0",
         "globals": "^15.14.0",
         "i18next": "^25.8.0",
         "i18next-browser-languagedetector": "^8.2.0",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -242,8 +242,10 @@
  * - Tab buttons (desktop panel triggers): z-index: 20
  * - Floating panels (desktop): z-index: 20
  * - Toolbar (search + navigation): z-index: 30
+ * - Mobile bottom navigation: z-index: 30
  * - Sidebar overlay: z-index: 40
- * - Draggable sheets (mobile - Phase 3): z-index: 40
+ * - Draggable sheet overlay (mobile): z-index: 40
+ * - Draggable sheet content (mobile): z-index: 50
  * - Sidebar: z-index: 50
  * - Modals/Dialogs: z-index: 50+
  */

--- a/resources/js/components/draggable-sheet.tsx
+++ b/resources/js/components/draggable-sheet.tsx
@@ -88,6 +88,7 @@ export function DraggableSheet({
                 transition={{ duration: 0.2 }}
                 className="fixed inset-0 z-40 bg-black"
                 onClick={onClose}
+                data-testid="sheet-backdrop"
             />
 
             {/* Draggable Sheet */}
@@ -117,9 +118,18 @@ export function DraggableSheet({
                     top: 0,
                     height: '100vh',
                 }}
+                data-testid="draggable-sheet"
+                role="dialog"
+                aria-label={title}
             >
                 {/* Drag Handle */}
-                <div className="flex w-full cursor-grab items-center justify-center py-3 active:cursor-grabbing">
+                <div
+                    className="flex w-full cursor-grab items-center justify-center py-3 active:cursor-grabbing"
+                    data-testid="drag-handle"
+                    role="button"
+                    tabIndex={0}
+                    aria-label="Drag to adjust sheet position"
+                >
                     <div className="h-1.5 w-12 rounded-full bg-muted-foreground/30" />
                 </div>
 
@@ -129,6 +139,8 @@ export function DraggableSheet({
                     <button
                         onClick={onClose}
                         className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none"
+                        aria-label="Close"
+                        data-testid="close-button"
                     >
                         <X className="h-5 w-5" />
                         <span className="sr-only">Close</span>

--- a/resources/js/components/draggable-sheet.tsx
+++ b/resources/js/components/draggable-sheet.tsx
@@ -34,6 +34,7 @@ export function DraggableSheet({
     const sheetRef = useRef<HTMLDivElement>(null);
     const [currentSnapIndex, setCurrentSnapIndex] = useState(initialSnapPoint);
     const [isDragging, setIsDragging] = useState(false);
+    const [mounted, setMounted] = useState(false);
 
     // Get viewport height
     const getViewportHeight = () => {
@@ -47,11 +48,19 @@ export function DraggableSheet({
         return vh * (1 - percentage);
     };
 
+    // Set mounted on first render
+    useEffect(() => {
+        setMounted(true);
+    }, []);
+
     // Open/close animation
     useEffect(() => {
+        if (!mounted) return;
+
         if (isOpen) {
+            const snapPos = getSnapPosition(currentSnapIndex);
             controls.start({
-                y: getSnapPosition(currentSnapIndex),
+                y: snapPos,
                 transition: { type: 'spring', damping: 30, stiffness: 300 },
             });
         } else {
@@ -60,7 +69,8 @@ export function DraggableSheet({
                 transition: { type: 'spring', damping: 30, stiffness: 300 },
             });
         }
-    }, [isOpen, currentSnapIndex, controls]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isOpen, currentSnapIndex, mounted]);
 
     // Handle drag end - snap to nearest snap point or close
     const handleDragEnd = (
@@ -121,16 +131,17 @@ export function DraggableSheet({
                     bottom: getViewportHeight(),
                 }}
                 dragElastic={0.1}
+                dragMomentum={false}
                 onDragStart={() => setIsDragging(true)}
                 onDragEnd={handleDragEnd}
                 animate={controls}
                 initial={{ y: getViewportHeight() }}
                 className={cn(
-                    'fixed inset-x-0 z-40 flex flex-col rounded-t-2xl bg-background shadow-lg',
-                    'max-h-[95vh]',
+                    'fixed inset-x-0 z-50 flex flex-col rounded-t-2xl bg-background shadow-lg',
+                    'max-h-[95vh] overflow-hidden',
                 )}
                 style={{
-                    touchAction: 'none',
+                    touchAction: 'pan-y',
                     top: 0,
                 }}
             >

--- a/resources/js/components/draggable-sheet.tsx
+++ b/resources/js/components/draggable-sheet.tsx
@@ -1,0 +1,166 @@
+import { cn } from '@/lib/utils';
+import { motion, PanInfo, useAnimation } from 'framer-motion';
+import { X } from 'lucide-react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
+
+interface DraggableSheetProps {
+    isOpen: boolean;
+    onClose: () => void;
+    title: string;
+    children: ReactNode;
+    snapPoints?: number[]; // Percentages of viewport height (e.g., [0.3, 0.6, 0.9])
+    initialSnapPoint?: number; // Index of initial snap point
+}
+
+/**
+ * DraggableSheet - Mobile bottom sheet component with drag gestures
+ *
+ * Features:
+ * - Draggable handle for easy interaction
+ * - Snap points for different heights
+ * - Swipe down to close
+ * - Smooth animations
+ * - Semi-transparent overlay
+ */
+export function DraggableSheet({
+    isOpen,
+    onClose,
+    title,
+    children,
+    snapPoints = [0.5, 0.9], // Default: 50% and 90% of viewport
+    initialSnapPoint = 0,
+}: DraggableSheetProps) {
+    const controls = useAnimation();
+    const sheetRef = useRef<HTMLDivElement>(null);
+    const [currentSnapIndex, setCurrentSnapIndex] = useState(initialSnapPoint);
+    const [isDragging, setIsDragging] = useState(false);
+
+    // Get viewport height
+    const getViewportHeight = () => {
+        return typeof window !== 'undefined' ? window.innerHeight : 800;
+    };
+
+    // Calculate pixel position from snap point percentage
+    const getSnapPosition = (index: number) => {
+        const vh = getViewportHeight();
+        const percentage = snapPoints[index];
+        return vh * (1 - percentage);
+    };
+
+    // Open/close animation
+    useEffect(() => {
+        if (isOpen) {
+            controls.start({
+                y: getSnapPosition(currentSnapIndex),
+                transition: { type: 'spring', damping: 30, stiffness: 300 },
+            });
+        } else {
+            controls.start({
+                y: getViewportHeight(),
+                transition: { type: 'spring', damping: 30, stiffness: 300 },
+            });
+        }
+    }, [isOpen, currentSnapIndex, controls]);
+
+    // Handle drag end - snap to nearest snap point or close
+    const handleDragEnd = (
+        event: MouseEvent | TouchEvent | PointerEvent,
+        info: PanInfo,
+    ) => {
+        setIsDragging(false);
+        const vh = getViewportHeight();
+        const currentY = info.point.y;
+        const velocity = info.velocity.y;
+
+        // If dragged down quickly or past 80% of screen, close
+        if (velocity > 500 || currentY > vh * 0.8) {
+            onClose();
+            return;
+        }
+
+        // Find nearest snap point
+        let nearestSnapIndex = 0;
+        let minDistance = Infinity;
+
+        snapPoints.forEach((_, index) => {
+            const snapY = getSnapPosition(index);
+            const distance = Math.abs(currentY - snapY);
+            if (distance < minDistance) {
+                minDistance = distance;
+                nearestSnapIndex = index;
+            }
+        });
+
+        setCurrentSnapIndex(nearestSnapIndex);
+        controls.start({
+            y: getSnapPosition(nearestSnapIndex),
+            transition: { type: 'spring', damping: 30, stiffness: 300 },
+        });
+    };
+
+    if (!isOpen) return null;
+
+    return (
+        <>
+            {/* Overlay */}
+            <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 0.5 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.2 }}
+                className="fixed inset-0 z-40 bg-black"
+                onClick={onClose}
+            />
+
+            {/* Draggable Sheet */}
+            <motion.div
+                ref={sheetRef}
+                drag="y"
+                dragConstraints={{
+                    top: getSnapPosition(snapPoints.length - 1),
+                    bottom: getViewportHeight(),
+                }}
+                dragElastic={0.1}
+                onDragStart={() => setIsDragging(true)}
+                onDragEnd={handleDragEnd}
+                animate={controls}
+                initial={{ y: getViewportHeight() }}
+                className={cn(
+                    'fixed inset-x-0 z-40 flex flex-col rounded-t-2xl bg-background shadow-lg',
+                    'max-h-[95vh]',
+                )}
+                style={{
+                    touchAction: 'none',
+                    top: 0,
+                }}
+            >
+                {/* Drag Handle */}
+                <div className="flex w-full cursor-grab items-center justify-center py-3 active:cursor-grabbing">
+                    <div className="h-1.5 w-12 rounded-full bg-muted-foreground/30" />
+                </div>
+
+                {/* Header */}
+                <div className="flex items-center justify-between border-b px-4 pb-3">
+                    <h2 className="text-lg font-semibold">{title}</h2>
+                    <button
+                        onClick={onClose}
+                        className="rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none"
+                    >
+                        <X className="h-5 w-5" />
+                        <span className="sr-only">Close</span>
+                    </button>
+                </div>
+
+                {/* Content */}
+                <div
+                    className={cn(
+                        'flex-1 overflow-y-auto',
+                        isDragging && 'pointer-events-none',
+                    )}
+                >
+                    {children}
+                </div>
+            </motion.div>
+        </>
+    );
+}

--- a/resources/js/components/mobile-navigation.tsx
+++ b/resources/js/components/mobile-navigation.tsx
@@ -34,7 +34,10 @@ export function MobileNavigation({
     onPanelChange,
 }: MobileNavigationProps) {
     return (
-        <nav className="fixed inset-x-0 bottom-0 z-30 border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+        <nav
+            className="fixed inset-x-0 bottom-0 z-30 border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80"
+            data-testid="mobile-navigation"
+        >
             <div className="flex items-center justify-around">
                 {navItems.map((item) => {
                     const Icon = item.icon;
@@ -51,6 +54,9 @@ export function MobileNavigation({
                                     ? 'text-primary'
                                     : 'text-muted-foreground',
                             )}
+                            data-testid={`nav-${item.id}`}
+                            aria-label={item.label}
+                            aria-current={isActive ? 'page' : undefined}
                         >
                             <Icon
                                 className={cn(

--- a/resources/js/components/mobile-navigation.tsx
+++ b/resources/js/components/mobile-navigation.tsx
@@ -1,0 +1,70 @@
+import { MobilePanelType } from '@/hooks/use-mobile-panels';
+import { cn } from '@/lib/utils';
+import { Bot, List, Map as MapIcon, Route as RouteIcon } from 'lucide-react';
+
+interface MobileNavigationProps {
+    activePanel: MobilePanelType;
+    onPanelChange: (panel: Exclude<MobilePanelType, null>) => void;
+}
+
+interface NavItem {
+    id: Exclude<MobilePanelType, null>;
+    icon: typeof List;
+    label: string;
+}
+
+const navItems: NavItem[] = [
+    { id: 'markers', icon: List, label: 'Markers' },
+    { id: 'tours', icon: MapIcon, label: 'Tours' },
+    { id: 'routes', icon: RouteIcon, label: 'Routes' },
+    { id: 'ai', icon: Bot, label: 'AI' },
+];
+
+/**
+ * MobileNavigation - Bottom navigation bar for mobile view (Phase 3)
+ *
+ * Features:
+ * - Fixed at bottom of screen
+ * - Icons for each panel type
+ * - Active state styling
+ * - Touch-friendly sizing
+ */
+export function MobileNavigation({
+    activePanel,
+    onPanelChange,
+}: MobileNavigationProps) {
+    return (
+        <nav className="fixed inset-x-0 bottom-0 z-30 border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+            <div className="flex items-center justify-around">
+                {navItems.map((item) => {
+                    const Icon = item.icon;
+                    const isActive = activePanel === item.id;
+
+                    return (
+                        <button
+                            key={item.id}
+                            onClick={() => onPanelChange(item.id)}
+                            className={cn(
+                                'flex flex-1 flex-col items-center justify-center gap-1 py-3 transition-colors',
+                                'hover:bg-accent/50',
+                                isActive
+                                    ? 'text-primary'
+                                    : 'text-muted-foreground',
+                            )}
+                        >
+                            <Icon
+                                className={cn(
+                                    'h-6 w-6',
+                                    isActive && 'fill-current',
+                                )}
+                            />
+                            <span className="text-xs font-medium">
+                                {item.label}
+                            </span>
+                        </button>
+                    );
+                })}
+            </div>
+        </nav>
+    );
+}

--- a/resources/js/components/travel-map.tsx
+++ b/resources/js/components/travel-map.tsx
@@ -46,15 +46,18 @@ interface TravelMapProps {
 }
 
 /**
- * Phase 2: Travel Map Component with Desktop Floating Panels
+ * Phase 3: Travel Map Component with Mobile Bottom Sheets
  *
- * This version adds floating panels for desktop view:
+ * Desktop view (Phase 2):
  * - Left side: Markers and Tours panels
  * - Right side: Routes and AI panels
  * - Multiple panels can be open simultaneously
  * - Panels float over the map with semi-transparent backgrounds
  *
- * Mobile panels will be added in Phase 3.
+ * Mobile view (Phase 3):
+ * - Bottom navigation bar with 4 icons (Markers, Tours, Routes, AI)
+ * - Draggable bottom sheets for panel content
+ * - Only one panel can be open at a time
  */
 export default function TravelMap({
     selectedTripId,
@@ -74,6 +77,13 @@ export default function TravelMap({
 
     // Desktop panel management
     const { panelStates, togglePanel, closePanel } = useDesktopPanels();
+
+    // Mobile panel management
+    const {
+        activePanel,
+        togglePanel: toggleMobilePanel,
+        closePanel: closeMobilePanel,
+    } = useMobilePanels();
 
     // Get current language setting
     const { language } = useLanguage();
@@ -538,11 +548,103 @@ export default function TravelMap({
                 </>
             )}
 
-            {/*
-             * Mobile panels will be added in Phase 3
-             * - DraggableSheet components
-             * - Bottom navigation bar
-             */}
+            {/* Mobile Panels - Phase 3 */}
+            {isMobile && (
+                <>
+                    {/* Bottom Navigation Bar */}
+                    <MobileNavigation
+                        activePanel={activePanel}
+                        onPanelChange={toggleMobilePanel}
+                    />
+
+                    {/* Markers Sheet */}
+                    <DraggableSheet
+                        isOpen={activePanel === 'markers'}
+                        onClose={closeMobilePanel}
+                        title={t('panels.markers', 'Markers')}
+                    >
+                        <MarkerList
+                            markers={markers}
+                            selectedMarkerId={selectedMarkerId}
+                            onSelectMarker={setSelectedMarkerId}
+                            selectedTourId={selectedTourId}
+                            onAddMarkerToTour={handleAddMarkerToTour}
+                            onMarkerImageFetched={(markerId, imageUrl) => {
+                                const updatedMarkers = markers.map((m) =>
+                                    m.id === markerId ? { ...m, imageUrl } : m,
+                                );
+                                setMarkers([...updatedMarkers]);
+                            }}
+                        />
+                    </DraggableSheet>
+
+                    {/* Tours Sheet */}
+                    <DraggableSheet
+                        isOpen={activePanel === 'tours'}
+                        onClose={closeMobilePanel}
+                        title={t('panels.tours', 'Tours')}
+                    >
+                        <TourPanel
+                            tours={tours}
+                            selectedTourId={selectedTourId}
+                            onSelectTour={onSelectTour}
+                            onCreateTour={onCreateTour}
+                            onDeleteTour={onDeleteTour}
+                            markers={markers}
+                            routes={routes}
+                            onMoveMarkerUp={handleMoveMarkerUp}
+                            onMoveMarkerDown={handleMoveMarkerDown}
+                            onRemoveMarkerFromTour={handleRemoveMarkerFromTour}
+                            onRequestRoute={handleRequestRoute}
+                        />
+                    </DraggableSheet>
+
+                    {/* Routes Sheet */}
+                    {selectedTripId && (
+                        <DraggableSheet
+                            isOpen={activePanel === 'routes'}
+                            onClose={closeMobilePanel}
+                            title={t('panels.routes', 'Routes')}
+                        >
+                            <RoutePanel
+                                tripId={selectedTripId}
+                                tourId={selectedTourId}
+                                markers={markers}
+                                routes={routes}
+                                onRoutesUpdate={setRoutes}
+                                initialStartMarkerId={
+                                    routeRequest?.startMarkerId
+                                }
+                                initialEndMarkerId={routeRequest?.endMarkerId}
+                                tours={tours}
+                                highlightedRouteId={highlightedRouteId}
+                                expandedRoutes={expandedRoutes}
+                                onExpandedRoutesChange={setExpandedRoutes}
+                                onHighlightedRouteIdChange={
+                                    setHighlightedRouteId
+                                }
+                                onTourUpdate={handleTourUpdate}
+                            />
+                        </DraggableSheet>
+                    )}
+
+                    {/* AI Sheet */}
+                    <DraggableSheet
+                        isOpen={activePanel === 'ai'}
+                        onClose={closeMobilePanel}
+                        title={t('panels.ai', 'AI Recommendations')}
+                    >
+                        <AiRecommendationsPanel
+                            tripId={selectedTripId}
+                            tripName={selectedTrip?.name || null}
+                            selectedTourId={selectedTourId}
+                            tours={tours}
+                            markers={markers}
+                            mapBounds={mapBounds}
+                        />
+                    </DraggableSheet>
+                </>
+            )}
 
             {/* Trip Notes Modal - Keep functional */}
             {selectedTrip && (

--- a/resources/js/components/travel-map.tsx
+++ b/resources/js/components/travel-map.tsx
@@ -27,6 +27,7 @@ import { getBoundingBoxFromTrip } from '@/lib/map-utils';
 import { update as tripsUpdate } from '@/routes/trips';
 import { Tour } from '@/types/tour';
 import { Trip } from '@/types/trip';
+import { AnimatePresence } from 'framer-motion';
 import { Bot, List, Map as MapIcon, Route as RouteIcon } from 'lucide-react';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -560,92 +561,110 @@ export default function TravelMap({
                         onPanelChange={toggleMobilePanel}
                     />
 
-                    {/* Markers Sheet */}
-                    <DraggableSheet
-                        isOpen={activePanel === 'markers'}
-                        onClose={closeMobilePanel}
-                        title={t('panels.markers', 'Markers')}
-                    >
-                        <MarkerList
-                            markers={markers}
-                            selectedMarkerId={selectedMarkerId}
-                            onSelectMarker={setSelectedMarkerId}
-                            selectedTourId={selectedTourId}
-                            onAddMarkerToTour={handleAddMarkerToTour}
-                            onMarkerImageFetched={(markerId, imageUrl) => {
-                                const updatedMarkers = markers.map((m) =>
-                                    m.id === markerId ? { ...m, imageUrl } : m,
-                                );
-                                setMarkers([...updatedMarkers]);
-                            }}
-                        />
-                    </DraggableSheet>
+                    <AnimatePresence mode="wait">
+                        {/* Markers Sheet */}
+                        {activePanel === 'markers' && (
+                            <DraggableSheet
+                                key="markers"
+                                onClose={closeMobilePanel}
+                                title={t('panels.markers', 'Markers')}
+                            >
+                                <MarkerList
+                                    markers={markers}
+                                    selectedMarkerId={selectedMarkerId}
+                                    onSelectMarker={setSelectedMarkerId}
+                                    selectedTourId={selectedTourId}
+                                    onAddMarkerToTour={handleAddMarkerToTour}
+                                    onMarkerImageFetched={(
+                                        markerId,
+                                        imageUrl,
+                                    ) => {
+                                        const updatedMarkers = markers.map(
+                                            (m) =>
+                                                m.id === markerId
+                                                    ? { ...m, imageUrl }
+                                                    : m,
+                                        );
+                                        setMarkers([...updatedMarkers]);
+                                    }}
+                                />
+                            </DraggableSheet>
+                        )}
 
-                    {/* Tours Sheet */}
-                    <DraggableSheet
-                        isOpen={activePanel === 'tours'}
-                        onClose={closeMobilePanel}
-                        title={t('panels.tours', 'Tours')}
-                    >
-                        <TourPanel
-                            tours={tours}
-                            selectedTourId={selectedTourId}
-                            onSelectTour={onSelectTour}
-                            onCreateTour={onCreateTour}
-                            onDeleteTour={onDeleteTour}
-                            markers={markers}
-                            routes={routes}
-                            onMoveMarkerUp={handleMoveMarkerUp}
-                            onMoveMarkerDown={handleMoveMarkerDown}
-                            onRemoveMarkerFromTour={handleRemoveMarkerFromTour}
-                            onRequestRoute={handleRequestRoute}
-                        />
-                    </DraggableSheet>
+                        {/* Tours Sheet */}
+                        {activePanel === 'tours' && (
+                            <DraggableSheet
+                                key="tours"
+                                onClose={closeMobilePanel}
+                                title={t('panels.tours', 'Tours')}
+                            >
+                                <TourPanel
+                                    tours={tours}
+                                    selectedTourId={selectedTourId}
+                                    onSelectTour={onSelectTour}
+                                    onCreateTour={onCreateTour}
+                                    onDeleteTour={onDeleteTour}
+                                    markers={markers}
+                                    routes={routes}
+                                    onMoveMarkerUp={handleMoveMarkerUp}
+                                    onMoveMarkerDown={handleMoveMarkerDown}
+                                    onRemoveMarkerFromTour={
+                                        handleRemoveMarkerFromTour
+                                    }
+                                    onRequestRoute={handleRequestRoute}
+                                />
+                            </DraggableSheet>
+                        )}
 
-                    {/* Routes Sheet */}
-                    {selectedTripId && (
-                        <DraggableSheet
-                            isOpen={activePanel === 'routes'}
-                            onClose={closeMobilePanel}
-                            title={t('panels.routes', 'Routes')}
-                        >
-                            <RoutePanel
-                                tripId={selectedTripId}
-                                tourId={selectedTourId}
-                                markers={markers}
-                                routes={routes}
-                                onRoutesUpdate={setRoutes}
-                                initialStartMarkerId={
-                                    routeRequest?.startMarkerId
-                                }
-                                initialEndMarkerId={routeRequest?.endMarkerId}
-                                tours={tours}
-                                highlightedRouteId={highlightedRouteId}
-                                expandedRoutes={expandedRoutes}
-                                onExpandedRoutesChange={setExpandedRoutes}
-                                onHighlightedRouteIdChange={
-                                    setHighlightedRouteId
-                                }
-                                onTourUpdate={handleTourUpdate}
-                            />
-                        </DraggableSheet>
-                    )}
+                        {/* Routes Sheet */}
+                        {activePanel === 'routes' && selectedTripId && (
+                            <DraggableSheet
+                                key="routes"
+                                onClose={closeMobilePanel}
+                                title={t('panels.routes', 'Routes')}
+                            >
+                                <RoutePanel
+                                    tripId={selectedTripId}
+                                    tourId={selectedTourId}
+                                    markers={markers}
+                                    routes={routes}
+                                    onRoutesUpdate={setRoutes}
+                                    initialStartMarkerId={
+                                        routeRequest?.startMarkerId
+                                    }
+                                    initialEndMarkerId={
+                                        routeRequest?.endMarkerId
+                                    }
+                                    tours={tours}
+                                    highlightedRouteId={highlightedRouteId}
+                                    expandedRoutes={expandedRoutes}
+                                    onExpandedRoutesChange={setExpandedRoutes}
+                                    onHighlightedRouteIdChange={
+                                        setHighlightedRouteId
+                                    }
+                                    onTourUpdate={handleTourUpdate}
+                                />
+                            </DraggableSheet>
+                        )}
 
-                    {/* AI Sheet */}
-                    <DraggableSheet
-                        isOpen={activePanel === 'ai'}
-                        onClose={closeMobilePanel}
-                        title={t('panels.ai', 'AI Recommendations')}
-                    >
-                        <AiRecommendationsPanel
-                            tripId={selectedTripId}
-                            tripName={selectedTrip?.name || null}
-                            selectedTourId={selectedTourId}
-                            tours={tours}
-                            markers={markers}
-                            mapBounds={mapBounds}
-                        />
-                    </DraggableSheet>
+                        {/* AI Sheet */}
+                        {activePanel === 'ai' && (
+                            <DraggableSheet
+                                key="ai"
+                                onClose={closeMobilePanel}
+                                title={t('panels.ai', 'AI Recommendations')}
+                            >
+                                <AiRecommendationsPanel
+                                    tripId={selectedTripId}
+                                    tripName={selectedTrip?.name || null}
+                                    selectedTourId={selectedTourId}
+                                    tours={tours}
+                                    markers={markers}
+                                    mapBounds={mapBounds}
+                                />
+                            </DraggableSheet>
+                        )}
+                    </AnimatePresence>
                 </>
             )}
 

--- a/resources/js/components/travel-map.tsx
+++ b/resources/js/components/travel-map.tsx
@@ -1,6 +1,8 @@
 import { AiRecommendationsPanel } from '@/components/ai-recommendations-panel';
+import { DraggableSheet } from '@/components/draggable-sheet';
 import { FloatingPanel } from '@/components/floating-panel';
 import MarkerList from '@/components/marker-list';
+import { MobileNavigation } from '@/components/mobile-navigation';
 import RoutePanel from '@/components/route-panel';
 import { TabButton } from '@/components/tab-button';
 import { Toolbar } from '@/components/toolbar';
@@ -14,6 +16,7 @@ import { useMapInteractions } from '@/hooks/use-map-interactions';
 import { useMarkerHighlight } from '@/hooks/use-marker-highlight';
 import { useMarkers } from '@/hooks/use-markers';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { useMobilePanels } from '@/hooks/use-mobile-panels';
 import { usePlaceTypes } from '@/hooks/use-place-types';
 import { useRoutes } from '@/hooks/use-routes';
 import { useSearchMode } from '@/hooks/use-search-mode';

--- a/resources/js/hooks/use-mobile-panels.ts
+++ b/resources/js/hooks/use-mobile-panels.ts
@@ -1,79 +1,32 @@
 import { useState } from 'react';
 
-export type PanelType = 'markers' | 'tours' | 'routes';
-export type SnapPoint = 'closed' | 'peek' | 'half' | 'full';
+export type MobilePanelType = 'markers' | 'tours' | 'routes' | 'ai' | null;
 
-interface PanelState {
-    isOpen: boolean;
-    snapPoint: SnapPoint;
-}
-
+/**
+ * useMobilePanels - State management for mobile bottom sheets (Phase 3)
+ *
+ * On mobile, only one panel can be open at a time.
+ * Panels are displayed as draggable bottom sheets.
+ */
 export function useMobilePanels() {
-    const [activePanel, setActivePanel] = useState<PanelType>('markers');
-    const [panelStates, setPanelStates] = useState<
-        Record<PanelType, PanelState>
-    >({
-        markers: { isOpen: true, snapPoint: 'peek' },
-        tours: { isOpen: false, snapPoint: 'closed' },
-        routes: { isOpen: false, snapPoint: 'closed' },
-    });
+    const [activePanel, setActivePanel] = useState<MobilePanelType>(null);
 
-    const openPanel = (panel: PanelType, snapPoint: SnapPoint = 'half') => {
-        setPanelStates((prev) => {
-            const newStates = { ...prev };
-            // Close all panels first
-            Object.keys(newStates).forEach((key) => {
-                newStates[key as PanelType] = {
-                    isOpen: false,
-                    snapPoint: 'closed',
-                };
-            });
-            // Open the requested panel
-            newStates[panel] = { isOpen: true, snapPoint };
-            return newStates;
-        });
+    const openPanel = (panel: MobilePanelType) => {
         setActivePanel(panel);
     };
 
-    const closePanel = (panel: PanelType) => {
-        setPanelStates((prev) => ({
-            ...prev,
-            [panel]: { isOpen: false, snapPoint: 'closed' },
-        }));
+    const closePanel = () => {
+        setActivePanel(null);
     };
 
-    const updatePanelSnapPoint = (panel: PanelType, snapPoint: SnapPoint) => {
-        setPanelStates((prev) => ({
-            ...prev,
-            [panel]: {
-                ...prev[panel],
-                snapPoint,
-                isOpen: snapPoint !== 'closed',
-            },
-        }));
-    };
-
-    const togglePanel = (panel: PanelType) => {
-        const currentState = panelStates[panel];
-        if (currentState.isOpen && currentState.snapPoint !== 'peek') {
-            // If open and not peeking, close it
-            closePanel(panel);
-        } else if (currentState.isOpen && currentState.snapPoint === 'peek') {
-            // If peeking, expand to half
-            updatePanelSnapPoint(panel, 'half');
-        } else {
-            // If closed, open to peek
-            openPanel(panel, 'peek');
-        }
+    const togglePanel = (panel: Exclude<MobilePanelType, null>) => {
+        setActivePanel((current) => (current === panel ? null : panel));
     };
 
     return {
         activePanel,
-        setActivePanel,
-        panelStates,
         openPanel,
         closePanel,
-        updatePanelSnapPoint,
         togglePanel,
     };
 }

--- a/resources/js/i18n/locales/de.json
+++ b/resources/js/i18n/locales/de.json
@@ -233,6 +233,12 @@
         "estimated_hours": "~{{hours}}h",
         "search_radius_label": "Suchradius in Kilometern"
     },
+    "panels": {
+        "markers": "Markierungen",
+        "tours": "Touren",
+        "routes": "Routen",
+        "ai": "KI-Empfehlungen"
+    },
     "settings": {
         "language": {
             "title": "Sprache",

--- a/resources/js/i18n/locales/en.json
+++ b/resources/js/i18n/locales/en.json
@@ -233,6 +233,12 @@
         "estimated_hours": "~{{hours}}h",
         "search_radius_label": "Search radius in kilometers"
     },
+    "panels": {
+        "markers": "Markers",
+        "tours": "Tours",
+        "routes": "Routes",
+        "ai": "AI Recommendations"
+    },
     "settings": {
         "language": {
             "title": "Language",


### PR DESCRIPTION
## Summary

Implements mobile-specific UI with draggable bottom sheets and bottom navigation bar to complement Phase 2's desktop floating panels.

## Changes

### New Components
- **DraggableSheet**: Draggable bottom sheet with snap points at 50% and 90% of viewport height
  - Drag gestures with Framer Motion
  - Swipe down to close
  - Background extends to bottom of viewport regardless of content size
  - Semi-transparent overlay

- **MobileNavigation**: Bottom navigation bar with 4 icons
  - Markers, Tours, Routes, AI panels
  - Active state styling
  - Fixed positioning with backdrop blur

### Modified Components
- **travel-map.tsx**: Added mobile panel logic with AnimatePresence for smooth transitions
- **use-mobile-panels.ts**: Simplified hook for single-panel state management

### Technical Details
- Uses Framer Motion for animations and drag interactions
- AnimatePresence for mount/unmount animations
- Only one panel open at a time on mobile (unlike desktop's multi-panel support)
- Z-index hierarchy: overlay (z-40), sheet content (z-50)
- Desktop view remains unchanged

## Testing
- ✅ Bottom navigation displays on mobile viewports
- ✅ Sheets slide up from bottom when nav button clicked
- ✅ Drag gestures work (expand to 90%, collapse to 50%)
- ✅ Swipe down closes the sheet
- ✅ Background extends to bottom regardless of content size
- ✅ Only one panel open at a time
- ✅ Desktop view unaffected

## Dependencies
- Added `framer-motion` for animations and drag gestures