### PR TITLE
Auto-open TourPanel when available marker is selected (issue #366)

### DIFF
--- a/resources/js/components/travel-map.tsx
+++ b/resources/js/components/travel-map.tsx
@@ -274,6 +274,13 @@ export default function TravelMap({
         }
     }, [selectedMarkerId, selectedTourId, isOpen, togglePanel]);
 
+    // Auto-open tour panel when an available marker is selected
+    useEffect(() => {
+        if (selectedAvailableMarkerId && !isOpen('tours')) {
+            togglePanel('tours');
+        }
+    }, [selectedAvailableMarkerId, isOpen, togglePanel]);
+
     // Handler for removing marker from tour
     const handleRemoveMarkerFromTour = useCallback(
         async (markerId: string) => {


### PR DESCRIPTION
## Summary
- Automatically opens the TourPanel when a user clicks on a marker (greyed-out or not) while a tour is selected
- Provides seamless workflow: click marker on map → TourPanel opens → marker selected in Available Markers list → click [+] to add

## Changes
- Added `useEffect` in `travel-map.tsx` that listens to `selectedAvailableMarkerId` changes
- Opens TourPanel automatically if not already open
- Consistent with existing auto-open behavior for markers panel
- Works on both desktop and mobile layouts

## Technical Details
The implementation follows the same pattern as the existing marker panel auto-open:
- Only triggers when `selectedAvailableMarkerId` is set
- Only opens if tours panel is not already open (prevents unnecessary re-renders)
- Dependencies: `[selectedAvailableMarkerId, isOpen, togglePanel]`

## Testing
- ✅ Build passes with no TypeScript errors
- ✅ useEffect follows React best practices
- ✅ Prevents infinite loops by checking `isOpen('tours')` before toggling

## User Experience
**Before**: User clicks marker → nothing happens → must manually open TourPanel → find marker in list

**After**: User clicks marker → TourPanel opens automatically → marker is highlighted with blue ring → auto-scrolls into view → ready to add

Closes #366