### PR TITLE
Improve Available Markers interaction and allow duplicate markers in tours (issue #372)

### DIFF
--- a/resources/js/components/available-markers.tsx
+++ b/resources/js/components/available-markers.tsx
@@ -1,3 +1,4 @@
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
     Collapsible,
@@ -12,7 +13,7 @@ import { ChevronDown, Plus } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 interface AvailableMarkersProps {
-    /** Markers that can be added to the tour (not already in tour) */
+    /** All markers that can be added to the tour (including those already in tour) */
     availableMarkers: MarkerData[];
     /** ID of the currently selected available marker (for blue ring highlight) */
     selectedAvailableMarkerId: string | null;
@@ -20,6 +21,8 @@ interface AvailableMarkersProps {
     onSelectAvailableMarker: (markerId: string | null) => void;
     /** Callback when the [+] button is clicked to add marker to tour */
     onAddMarkerToTour: (markerId: string) => void;
+    /** Function to get how many times a marker is in the current tour */
+    getMarkerCountInTour: (markerId: string) => number;
 }
 
 export function AvailableMarkers({
@@ -27,6 +30,7 @@ export function AvailableMarkers({
     selectedAvailableMarkerId,
     onSelectAvailableMarker,
     onAddMarkerToTour,
+    getMarkerCountInTour,
 }: AvailableMarkersProps) {
     const [isOpen, setIsOpen] = useState(true);
     const selectedMarkerRef = useRef<HTMLLIElement>(null);
@@ -99,6 +103,19 @@ export function AvailableMarkers({
                                                     {marker.name ||
                                                         'Unnamed Location'}
                                                 </div>
+                                                {getMarkerCountInTour(
+                                                    marker.id,
+                                                ) > 0 && (
+                                                    <Badge
+                                                        variant="outline"
+                                                        className="mt-0.5 border-blue-200 bg-blue-50 text-xs text-blue-700 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300"
+                                                    >
+                                                        {getMarkerCountInTour(
+                                                            marker.id,
+                                                        )}
+                                                        x in tour
+                                                    </Badge>
+                                                )}
                                                 {marker.estimatedHours && (
                                                     <div className="text-xs leading-relaxed text-gray-600 dark:text-gray-400">
                                                         ~{marker.estimatedHours}

--- a/resources/js/components/available-markers.tsx
+++ b/resources/js/components/available-markers.tsx
@@ -103,19 +103,22 @@ export function AvailableMarkers({
                                                     {marker.name ||
                                                         'Unnamed Location'}
                                                 </div>
-                                                {getMarkerCountInTour(
-                                                    marker.id,
-                                                ) > 0 && (
-                                                    <Badge
-                                                        variant="outline"
-                                                        className="mt-0.5 border-blue-200 bg-blue-50 text-xs text-blue-700 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300"
-                                                    >
-                                                        {getMarkerCountInTour(
+                                                {(() => {
+                                                    const count =
+                                                        getMarkerCountInTour(
                                                             marker.id,
-                                                        )}
-                                                        x in tour
-                                                    </Badge>
-                                                )}
+                                                        );
+                                                    return (
+                                                        count > 0 && (
+                                                            <Badge
+                                                                variant="outline"
+                                                                className="mt-0.5 border-blue-200 bg-blue-50 text-xs text-blue-700 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-300"
+                                                            >
+                                                                {count}x in tour
+                                                            </Badge>
+                                                        )
+                                                    );
+                                                })()}
                                                 {marker.estimatedHours && (
                                                     <div className="text-xs leading-relaxed text-gray-600 dark:text-gray-400">
                                                         ~{marker.estimatedHours}

--- a/resources/js/components/tour-panel.tsx
+++ b/resources/js/components/tour-panel.tsx
@@ -193,23 +193,21 @@ function TourCard({
     onSelectAvailableMarker,
     onAddMarkerToTour,
 }: TourCardProps) {
-    // Calculate available markers (not in tour)
-    const tourMarkerIds = useMemo(
-        () => new Set(markers.map((m) => m.id)),
-        [markers],
-    );
+    // Function to count how many times a marker appears in the tour
+    const getMarkerCountInTour = (markerId: string): number => {
+        return markers.filter((m) => m.id === markerId).length;
+    };
 
+    // Show all markers (including those already in tour)
     const availableMarkers = useMemo(
         () =>
-            allMarkers
-                .filter((marker) => !tourMarkerIds.has(marker.id))
-                .sort((a, b) =>
-                    (a.name || '').localeCompare(b.name || '', undefined, {
-                        numeric: true,
-                        sensitivity: 'base',
-                    }),
-                ),
-        [allMarkers, tourMarkerIds],
+            allMarkers.sort((a, b) =>
+                (a.name || '').localeCompare(b.name || '', undefined, {
+                    numeric: true,
+                    sensitivity: 'base',
+                }),
+            ),
+        [allMarkers],
     );
     return (
         <Card className="flex-1 overflow-auto p-3 sm:p-3 md:p-4">
@@ -335,6 +333,7 @@ function TourCard({
                     }
                     onSelectAvailableMarker={onSelectAvailableMarker}
                     onAddMarkerToTour={onAddMarkerToTour}
+                    getMarkerCountInTour={getMarkerCountInTour}
                 />
             )}
         </Card>

--- a/resources/js/components/tour-panel.tsx
+++ b/resources/js/components/tour-panel.tsx
@@ -193,15 +193,27 @@ function TourCard({
     onSelectAvailableMarker,
     onAddMarkerToTour,
 }: TourCardProps) {
+    // Precompute marker counts for O(1) lookup performance
+    const markerCountsInTour = useMemo(() => {
+        const counts = new Map<string, number>();
+
+        for (const marker of markers) {
+            const currentCount = counts.get(marker.id) ?? 0;
+            counts.set(marker.id, currentCount + 1);
+        }
+
+        return counts;
+    }, [markers]);
+
     // Function to count how many times a marker appears in the tour
     const getMarkerCountInTour = (markerId: string): number => {
-        return markers.filter((m) => m.id === markerId).length;
+        return markerCountsInTour.get(markerId) ?? 0;
     };
 
     // Show all markers (including those already in tour)
     const availableMarkers = useMemo(
         () =>
-            allMarkers.sort((a, b) =>
+            [...allMarkers].sort((a, b) =>
                 (a.name || '').localeCompare(b.name || '', undefined, {
                     numeric: true,
                     sensitivity: 'base',

--- a/resources/js/components/travel-map.tsx
+++ b/resources/js/components/travel-map.tsx
@@ -236,11 +236,18 @@ export default function TravelMap({
         tours,
         onMarkerUpdated: updateMarkerReference,
         onMarkerClick: (markerId: string) => {
-            // If we are in tour context (tour selected + tours panel open), stay there: do not open marker form
+            // If we are in tour context (tour selected + tours panel open), select in Available Markers
             const isInTourContext = selectedTourId !== null && isOpen('tours');
-            setSelectedMarkerId(markerId);
-            if (!isInTourContext && !isOpen('markers')) {
-                togglePanel('markers');
+
+            if (isInTourContext) {
+                // In tour context: Select marker in Available Markers list (blue ring)
+                setSelectedAvailableMarkerId(markerId);
+            } else {
+                // Outside tour context: Select marker normally (open marker form)
+                setSelectedMarkerId(markerId);
+                if (!isOpen('markers')) {
+                    togglePanel('markers');
+                }
             }
         },
     });

--- a/resources/js/hooks/use-marker-styling.ts
+++ b/resources/js/hooks/use-marker-styling.ts
@@ -75,10 +75,8 @@ export function useMarkerStyling({
             // If no tour selected, nothing is greyed out
             const isGreyedOut = tourMarkerIds ? !isInSelectedTour : false;
 
-            // Blue ring for selected available marker (not in tour, but selected)
-            const hasBlueRing =
-                selectedAvailableMarkerId === markerData.id &&
-                !isInSelectedTour;
+            // Blue ring for selected available marker (shows for all selected markers, regardless of tour membership)
+            const hasBlueRing = selectedAvailableMarkerId === markerData.id;
 
             const el = createMarkerElement({
                 type: markerData.type,


### PR DESCRIPTION
## Summary
- Clicking any marker on the map now selects it in Available Markers (with blue ring)
- Available Markers list now shows all markers, including those already in tour
- Markers already in tour display a blue badge showing "Nx in tour"
- Users can add the same marker to a tour multiple times

## Changes

### 1. tour-panel.tsx
- Removed filter that excluded markers already in tour from Available Markers list
- Added `getMarkerCountInTour()` function to count occurrences of each marker in tour
- Simplified `availableMarkers` to show all markers sorted by name
- Passed `getMarkerCountInTour` prop to AvailableMarkers component

### 2. available-markers.tsx
- Added Badge component import
- Extended props to include `getMarkerCountInTour` function
- Added badge display showing "Nx in tour" when marker count > 0
- Badge positioned under marker name with blue color scheme

### 3. travel-map.tsx
- Modified `onMarkerClick` callback to detect tour context
- When TourPanel is open with a selected tour: clicking a marker sets `selectedAvailableMarkerId` instead of opening marker form
- When outside tour context: maintains existing behavior (opens marker form)

### 4. use-marker-styling.ts
- Simplified blue ring condition to show for any selected available marker
- Removed restriction that prevented blue ring for markers already in tour
- Blue ring now appears consistently when marker is selected in Available Markers

## User Experience

### Before
- Clicking markers in tour context opened marker edit form
- Available Markers list excluded markers already added to tour
- No visual indication of how many times a marker appears in tour
- Users couldn't add same marker multiple times

### After
- Clicking markers when TourPanel is open selects them in Available Markers list
- Blue ring appears around selected marker (whether in tour or not)
- Available Markers shows all markers with "Nx in tour" badge for those already added
- Users can add same marker multiple times to create repeated stops

## Technical Details
- Backend already supports duplicate markers in tours
- Blue ring selection works for both greyed-out and highlighted markers
- Badge uses consistent blue color scheme: `bg-blue-50 text-blue-700 border-blue-200`
- Auto-scroll to selected marker in Available Markers (existing functionality preserved)

## Related Issues
- Fixes #372
- Part of #185 (Tour Mode - UX improvements)

## Testing
- ✅ Build successful with no TypeScript errors
- ✅ All 4 files modified and tested together
- ✅ Verified marker selection in tour context
- ✅ Verified badge display for markers in tour
- ✅ Verified duplicate marker addition capability