### PR TITLE
Restore tour lines visualization between consecutive markers (issue #376)

### DIFF
--- a/resources/js/components/travel-map.tsx
+++ b/resources/js/components/travel-map.tsx
@@ -22,6 +22,7 @@ import { useRoutes } from '@/hooks/use-routes';
 import { useSearchMode } from '@/hooks/use-search-mode';
 import { useSearchRadius } from '@/hooks/use-search-radius';
 import { useSearchResults } from '@/hooks/use-search-results';
+import { useTourLines } from '@/hooks/use-tour-lines';
 import { useTourMarkers } from '@/hooks/use-tour-markers';
 import { getBoundingBoxFromTrip } from '@/lib/map-utils';
 import { update as tripsUpdate } from '@/routes/trips';
@@ -204,6 +205,15 @@ export default function TravelMap({
                 handleRouteClickRef.current(routeId);
             }
         },
+    });
+
+    // Tour lines - draw curved lines between markers in selected tour when no route exists
+    useTourLines({
+        mapInstance,
+        selectedTourId,
+        tours,
+        markers,
+        routes,
     });
 
     // Tour markers management


### PR DESCRIPTION
## Summary
Restores the tour lines visualization feature that was accidentally removed during the "Phase 1: Implement fullscreen map with toolbar" refactoring. The `useTourLines` hook was fully implemented but not being used in the application.

## Changes

### File: `resources/js/components/travel-map.tsx`

**1. Added import (line 25):**
```typescript
import { useTourLines } from '@/hooks/use-tour-lines';
```

**2. Added hook call (after `useRoutes`, lines 210-216):**
```typescript
// Tour lines - draw curved lines between markers in selected tour when no route exists
useTourLines({
    mapInstance,
    selectedTourId,
    tours,
    markers,
    routes,
});
```

## Behavior

### What Tour Lines Do
- Display **blue curved lines** between consecutive markers in a selected tour
- Lines only appear when **no calculated route exists** between markers
- When a route is calculated, the route rendering takes over
- Lines have **hover effects**: cursor changes to pointer, line becomes thicker

### Visual Style
- **Color**: Blue (#3b82f6)
- **Width**: 5px (7px on hover)
- **Opacity**: 0.7 (0.8 on hover)
- **Shape**: Curved Bezier curves with 15% perpendicular offset

### User Experience
**Before:**
- No visual connection between tour markers
- Had to rely on mental visualization of tour order
- Only calculated routes were visible

**After:**
- Blue curved lines connect consecutive markers in tour
- Provides immediate visual feedback of tour path
- Lines automatically hide when routes are calculated
- Hover effects provide interactive feedback

## Technical Details

### Existing Implementation
The `useTourLines` hook (implemented in commit f909f71) was already complete:
- Location: `resources/js/hooks/use-tour-lines.ts`
- 243 lines of fully implemented code
- Features: Bezier curve generation, layer management, hover effects, click handling
- Layer ordering: Properly integrated with map layer hierarchy

### What Was Missing
The hook was removed in commit a765e73 (Feb 14 2026) during major refactoring of `travel-map.tsx`. This PR simply re-integrates the existing hook.

### Integration Points
- Listens to `selectedTourId`, `tours`, `markers`, and `routes`
- Automatically updates when tour selection changes
- Coordinates with `useRoutes` hook to avoid duplicate rendering
- Layer management handled by `ensureVectorLayerOrder()` from `map-layers.ts`

## Testing
- ✅ Build successful with no TypeScript errors
- ✅ Hook properly imported and called
- ✅ All required parameters passed correctly
- ✅ map-D2xlmbix.js bundle size increased by ~23KB (expected, includes tour lines logic)

## Related
- Fixes #376
- Part of #185 (Tours EPIC)
- Original implementation: commit f909f71
- Accidentally removed: commit a765e73