### PR TITLE
Fix: Invalid longitude values in search bounding box calculation (issue #384)

### DIFF
--- a/resources/js/lib/map-utils.ts
+++ b/resources/js/lib/map-utils.ts
@@ -54,10 +54,14 @@ export function calculateBoundingBoxFromViewport(
 
     const lngDelta = viewportWidthMeters / (111320 * cosLat) / 2;
 
-    const west = longitude - lngDelta;
+    let west = longitude - lngDelta;
     const south = latitude - latDelta;
-    const east = longitude + lngDelta;
+    let east = longitude + lngDelta;
     const north = latitude + latDelta;
+
+    // Clamp longitude values to valid range (-180 to 180)
+    west = Math.max(-180, Math.min(180, west));
+    east = Math.max(-180, Math.min(180, east));
 
     // Validate results
     if (
@@ -66,6 +70,11 @@ export function calculateBoundingBoxFromViewport(
         !isFinite(east) ||
         !isFinite(north)
     ) {
+        return undefined;
+    }
+
+    // Validate latitude range
+    if (south < -90 || north > 90) {
         return undefined;
     }
 


### PR DESCRIPTION
## Summary

Fixes a bug where the search box throws console errors and fails to return results due to invalid longitude values in the bounding box calculation.

## Problem

When typing in the search box, the following error appears in console:
```
Uncaught (in promise) Error: Invalid LngLat longitude value: must be between -180 and 180
```

This prevents search results from being displayed.

## Root Cause

The `calculateBoundingBoxFromViewport` function in `lib/map-utils.ts` calculates bounding box coordinates that can exceed valid ranges:
- **Longitude (west/east)**: Must be between -180 and 180
- **Latitude (south/north)**: Must be between -90 and 90

When the viewport is near the dateline or poles, the calculated deltas can push values outside these ranges. These invalid values were passed directly to Mapbox SearchBox, causing the error.

## Solution

Added coordinate validation and clamping:

1. **Clamp longitude values** to -180...180 range
   ```typescript
   west = Math.max(-180, Math.min(180, west));
   east = Math.max(-180, Math.min(180, east));
   ```

2. **Validate latitude values** and return `undefined` if out of range
   ```typescript
   if (south < -90 || north > 90) {
       return undefined;
   }
   ```

3. The SearchBox components already handle `undefined` bbox gracefully (falls back to global search)

## Changes

- Modified `calculateBoundingBoxFromViewport()` in `resources/js/lib/map-utils.ts`
- Added longitude clamping to valid range
- Added latitude range validation
- No changes to component code needed (already handles undefined)

## Testing

- ✅ `npm run build` passes without errors
- ✅ Search box now works without console errors
- ✅ Bounding box calculations remain accurate within valid ranges
- ✅ Gracefully falls back to global search if bbox is invalid

## Impact

- **User-facing**: Search functionality now works correctly
- **Developer-facing**: No more console errors during search
- **Breaking changes**: None

## Related Issues

- Closes #384

## Type

- 🐛 Bug fix
- No breaking changes