### PR TITLE
Fix Log Viewer API 401 errors on non-localhost domains

### DIFF
--- a/config/log-viewer.php
+++ b/config/log-viewer.php
@@ -113,7 +113,6 @@ return [
     'api_middleware' => [
         'web',
         'auth',
-        \Opcodes\LogViewer\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
         \Opcodes\LogViewer\Http\Middleware\AuthorizeLogViewer::class,
     ],
 


### PR DESCRIPTION
## Summary

Fixes 401 Unauthenticated errors when accessing Log Viewer API endpoints on domains that don't match `APP_URL` (e.g., `dev.travelmap.koller.dk` when `APP_URL` is `localhost`).

## Problem

When clicking on a log file in the Log Viewer UI, the API request to `/admin/logs/api/logs` returns 401 Unauthenticated. This happens because the `EnsureFrontendRequestsAreStateful` middleware checks if requests originate from configured "stateful domains" and blocks requests from unrecognized domains.

## Solution

Remove `EnsureFrontendRequestsAreStateful` middleware from `api_middleware` configuration. This middleware is designed for API token authentication (similar to Sanctum) but is unnecessary for our session-based authentication setup. The `web` middleware group already provides proper session handling.

## Changes

- Remove `\Opcodes\LogViewer\Http\Middleware\EnsureFrontendRequestsAreStateful::class` from `config/log-viewer.php` api_middleware array
- Authentication and authorization still enforced through:
  - `auth` middleware (ensures user is authenticated)
  - `AuthorizeLogViewer` middleware (calls our custom `LogViewer::auth()` callback)
  - Custom auth callback in `AppServiceProvider` (checks `$user->isAdmin()`)

## Testing

- ✅ All tests passing (31 route authentication tests)
- ✅ Admin users can access Log Viewer UI
- ✅ Admin users can view log files and entries
- ✅ Non-admin users receive 403 Forbidden