### PR TITLE
Fix PDF export: Prevent marker blocks from breaking across pages

### DIFF
--- a/resources/views/trip-pdf.blade.php
+++ b/resources/views/trip-pdf.blade.php
@@ -99,6 +99,9 @@
             font-weight: bold;
             color: #1f2937;
             margin-bottom: 10px;
+            
+            /* Optional: Neue Seite vor einer Tour beginnen wenn wenig Platz */
+            page-break-before: auto;
         }
         
         .marker-list {
@@ -111,6 +114,14 @@
             background-color: #f9fafb;
             border-left: 3px solid #3b82f6;
             border-radius: 4px;
+            
+            /* Verhindert Seitenumbruch innerhalb des Markers */
+            page-break-inside: avoid;
+            break-inside: avoid;
+            
+            /* Minimale Zeilen am Seiten-Ende/-Anfang */
+            orphans: 3;
+            widows: 3;
         }
         
         .marker-name {
@@ -118,6 +129,9 @@
             font-weight: bold;
             color: #1f2937;
             margin-bottom: 4px;
+            
+            /* Verhindert Umbruch zwischen Marker-Name und Content */
+            page-break-after: avoid;
         }
         
         .marker-detail {
@@ -132,6 +146,11 @@
             margin-top: 6px;
             padding-top: 6px;
             border-top: 1px solid #e5e7eb;
+            
+            /* Notes können bei sehr langen Texten umbrochen werden,
+               aber Header und Content bleiben zusammen */
+            orphans: 2;
+            widows: 2;
         }
         
         /* Markdown formatting styles for notes */
@@ -226,6 +245,10 @@
             display: table;
             width: 100%;
             margin-bottom: 10px;
+            
+            /* Auch den Content-Bereich schützen */
+            page-break-inside: avoid;
+            break-inside: avoid;
         }
         
         .marker-left {

--- a/tests/Feature/TripPdfExportTest.php
+++ b/tests/Feature/TripPdfExportTest.php
@@ -223,7 +223,7 @@ test('generates PDF with proper marker layout', function () {
     $response = $this->actingAs($user)->get("/trips/{$trip->id}/export-pdf");
 
     $response->assertSuccessful();
-    $response->assertHeader('content-type', 'application/pdf');
+    $response->assertHeader('Content-Type', 'application/pdf');
 
     // Note: Actual page break validation would require PDF parsing library
     // This test ensures the PDF generation doesn't crash with many markers

--- a/tests/Feature/TripPdfExportTest.php
+++ b/tests/Feature/TripPdfExportTest.php
@@ -198,3 +198,33 @@ test('prevents exporting PDF for other users trips', function () {
 
     $response->assertForbidden();
 });
+
+test('generates PDF with proper marker layout', function () {
+    // Mock MapboxStaticImageService to prevent real API calls
+    $this->mock(MapboxStaticImageService::class, function ($mock) {
+        $mock->shouldReceive('generateStaticImageWithMarkers')
+            ->andReturn('https://api.mapbox.com/styles/v1/test/static/test.png');
+    });
+
+    $user = User::factory()->create();
+    $trip = Trip::factory()->for($user)->create();
+    $tour = Tour::factory()->for($trip)->create();
+
+    // Create many markers to force multiple pages
+    $markers = Marker::factory()
+        ->count(20)
+        ->for($trip)
+        ->create([
+            'notes' => fake()->paragraphs(3, true), // Longer notes
+        ]);
+
+    $tour->markers()->attach($markers->pluck('id'));
+
+    $response = $this->actingAs($user)->get("/trips/{$trip->id}/export-pdf");
+
+    $response->assertSuccessful();
+    $response->assertHeader('content-type', 'application/pdf');
+
+    // Note: Actual page break validation would require PDF parsing library
+    // This test ensures the PDF generation doesn't crash with many markers
+});


### PR DESCRIPTION
## Summary

Fixes #421

This PR implements CSS page-break rules to prevent marker blocks from being interrupted by page breaks in PDF exports. Each marker block now stays together as a complete unit on a single page.

## Changes Made

### CSS Improvements in `trip-pdf.blade.php`

1. **`.marker-item`** - Added `page-break-inside: avoid` and `break-inside: avoid` to keep entire marker blocks together
2. **`.marker-name`** - Added `page-break-after: avoid` to prevent breaks between marker name and content
3. **`.marker-content`** - Added page-break protection for the content area
4. **`.marker-notes`** - Configured `orphans` and `widows` for better text flow in long notes
5. **`.tour-header`** - Added `page-break-before: auto` for optimal tour section placement

### Testing

- Added new test case `generates PDF with proper marker layout` that creates 20 markers with long notes to verify PDF generation with many markers doesn't crash
- All existing tests pass (591 passed)
- Code formatted with Pint and Prettier

## How to Test

1. Create a trip with 15-20 markers
2. Add varying content to markers (with/without images, short/long notes)
3. Export to PDF via `/trips/{trip_id}/export-pdf`
4. Verify that marker blocks are not interrupted by page breaks
5. Check that markers with very long notes (500+ characters) stay together

## DomPDF Compatibility

The implementation uses DomPDF-compatible CSS properties:
- `page-break-inside: avoid` (primary)
- `break-inside: avoid` (modern CSS fallback)
- `orphans` and `widows` for text flow control

## Notes

- Very large markers (>90% of page height) may still break due to DomPDF limitations
- The test verifies successful PDF generation but doesn't parse PDF structure (would require additional PDF parsing library)