### PR TITLE
Add summary page with statistics to PDF export

### DIFF
--- a/app/Services/TripPdfExportService.php
+++ b/app/Services/TripPdfExportService.php
@@ -62,7 +62,10 @@ class TripPdfExportService
         $tableOfContents = $this->buildTableOfContents($toursData, count($markers));
 
         // Calculate summary statistics
-        $summaryStats = $this->calculateSummaryStats($trip, $toursData);
+        $summaryStats = $this->calculateSummaryStats($trip, $toursData, $tours);
+
+        // Generate consistent timestamp for the entire PDF
+        $generatedAt = now();
 
         $pdf = Pdf::loadView('trip-pdf', [
             'trip' => $trip,
@@ -74,6 +77,7 @@ class TripPdfExportService
             'tours' => $toursData,
             'tableOfContents' => $tableOfContents,
             'summaryStats' => $summaryStats,
+            'generatedAt' => $generatedAt,
         ]);
 
         // Generate a safe filename from the trip name
@@ -144,7 +148,7 @@ class TripPdfExportService
      * @param  array  $toursData  Prepared tours data array
      * @return array Summary statistics
      */
-    private function calculateSummaryStats(Trip $trip, array $toursData): array
+    private function calculateSummaryStats(Trip $trip, array $toursData, $tours): array
     {
         $totalLocations = 0;
         $totalDuration = 0.0;
@@ -162,11 +166,11 @@ class TripPdfExportService
 
             // Calculate distance for this tour
             $tourDistance = 0.0;
-            $tourModel = $trip->tours->firstWhere('id', $tour['id']);
+            $tourModel = $tours->firstWhere('id', $tour['id']);
             if ($tourModel) {
                 foreach ($tourModel->routes as $route) {
                     if (! empty($route->distance)) {
-                        $routeDistanceKm = $route->distance / 1000; // Convert meters to km
+                        $routeDistanceKm = $route->distance_in_km;
                         $tourDistance += $routeDistanceKm;
                         $totalDistance += $routeDistanceKm;
                     }

--- a/app/Services/TripPdfExportService.php
+++ b/app/Services/TripPdfExportService.php
@@ -61,6 +61,9 @@ class TripPdfExportService
         // Build table of contents
         $tableOfContents = $this->buildTableOfContents($toursData, count($markers));
 
+        // Calculate summary statistics
+        $summaryStats = $this->calculateSummaryStats($trip, $toursData);
+
         $pdf = Pdf::loadView('trip-pdf', [
             'trip' => $trip,
             'tripImageUrl' => $tripImageBase64,
@@ -70,6 +73,7 @@ class TripPdfExportService
             'markersCount' => count($markers),
             'tours' => $toursData,
             'tableOfContents' => $tableOfContents,
+            'summaryStats' => $summaryStats,
         ]);
 
         // Generate a safe filename from the trip name
@@ -133,6 +137,92 @@ class TripPdfExportService
     }
 
     /**
+     * Calculate trip summary statistics.
+     * Computes total locations, tours, duration, distance, UNESCO sites, and marker type distribution.
+     *
+     * @param  Trip  $trip  The trip instance
+     * @param  array  $toursData  Prepared tours data array
+     * @return array Summary statistics
+     */
+    private function calculateSummaryStats(Trip $trip, array $toursData): array
+    {
+        $totalLocations = 0;
+        $totalDuration = 0.0;
+        $totalDistance = 0.0;
+        $unescoCount = 0;
+        $markerTypes = [];
+        $tourBreakdown = [];
+
+        foreach ($toursData as $tour) {
+            $tourLocationCount = count($tour['markers']);
+            $totalLocations += $tourLocationCount;
+
+            $tourDuration = (float) ($tour['estimated_duration_hours'] ?? 0);
+            $totalDuration += $tourDuration;
+
+            // Calculate distance for this tour
+            $tourDistance = 0.0;
+            $tourModel = $trip->tours->firstWhere('id', $tour['id']);
+            if ($tourModel) {
+                foreach ($tourModel->routes as $route) {
+                    if (! empty($route->distance)) {
+                        $routeDistanceKm = $route->distance / 1000; // Convert meters to km
+                        $tourDistance += $routeDistanceKm;
+                        $totalDistance += $routeDistanceKm;
+                    }
+                }
+            }
+
+            // Tour breakdown
+            $tourBreakdown[] = [
+                'name' => $tour['name'],
+                'markerCount' => $tourLocationCount,
+                'duration' => $tourDuration,
+                'distance' => $tourDistance,
+            ];
+
+            // Process markers
+            foreach ($tour['markers'] as $marker) {
+                // Count UNESCO sites
+                if ($marker['is_unesco']) {
+                    $unescoCount++;
+                }
+
+                // Count marker types
+                $type = $marker['type'] ?? 'other';
+                if (! isset($markerTypes[$type])) {
+                    $markerTypes[$type] = 0;
+                }
+                $markerTypes[$type]++;
+            }
+        }
+
+        // Sort marker types by count (descending)
+        arsort($markerTypes);
+
+        // Convert marker types to distribution array with percentages
+        $markerTypeDistribution = [];
+        foreach ($markerTypes as $type => $count) {
+            $percentage = $totalLocations > 0 ? (int) round(($count / $totalLocations) * 100) : 0;
+            $markerTypeDistribution[] = [
+                'type' => $type,
+                'count' => $count,
+                'percentage' => $percentage,
+            ];
+        }
+
+        return [
+            'totalLocations' => $totalLocations,
+            'totalTours' => count($toursData),
+            'totalDuration' => $totalDuration,
+            'totalDistance' => $totalDistance,
+            'unescoCount' => $unescoCount,
+            'tourBreakdown' => $tourBreakdown,
+            'markerTypeDistribution' => $markerTypeDistribution,
+        ];
+    }
+
+    /**
      * Prepare tour data with markers, routes, and static maps.
      */
     private function prepareToursData(\Illuminate\Database\Eloquent\Collection $tours): array
@@ -187,6 +277,7 @@ class TripPdfExportService
             $tourMapBase64 = $this->generateTourMap($tour, $tourMarkers, $tourRoutes);
 
             $toursData[] = [
+                'id' => $tour->id,
                 'name' => $tour->name,
                 'markers' => $tourMarkers,
                 'mapUrl' => $tourMapBase64,

--- a/resources/views/trip-pdf.blade.php
+++ b/resources/views/trip-pdf.blade.php
@@ -1031,7 +1031,7 @@
             </div>
             
             <div class="pdf-footer">
-                Generated on {{ now()->format('F j, Y \a\t g:i A') }}
+                Generated on {{ $generatedAt->format('F j, Y \a\t g:i A') }}
             </div>
         </div>
         
@@ -1082,7 +1082,7 @@
             </div>
 
             <div class="pdf-footer">
-                Generated on {{ now()->format('F j, Y \a\t g:i A') }}
+                Generated on {{ $generatedAt->format('F j, Y \a\t g:i A') }}
             </div>
         </div>
     @endif
@@ -1192,7 +1192,7 @@
             </div>
 
             <div class="pdf-footer">
-                Generated on {{ now()->format('F j, Y \a\t g:i A') }}
+                Generated on {{ $generatedAt->format('F j, Y \a\t g:i A') }}
             </div>
         </div>
     @endforeach
@@ -1280,10 +1280,6 @@
             <div class="summary-section">
                 <h2 class="summary-section-title">Marker Type Distribution</h2>
                 <div class="summary-distribution">
-                    @php
-                        $maxCount = max(array_column($summaryStats['markerTypeDistribution'], 'count'));
-                    @endphp
-                    
                     @foreach($summaryStats['markerTypeDistribution'] as $typeItem)
                         <div class="summary-distribution-item">
                             <div class="summary-distribution-label-cell">
@@ -1305,7 +1301,7 @@
                             </div>
                             <div class="summary-distribution-bar-cell">
                                 <div class="summary-progress-bar-bg">
-                                    <div class="summary-progress-bar-fill" style="width: {{ $maxCount > 0 ? ($typeItem['count'] / $maxCount * 100) : 0 }}%;"></div>
+                                    <div class="summary-progress-bar-fill" style="width: {{ $typeItem['percentage'] }}%;"></div>
                                 </div>
                             </div>
                             <div class="summary-distribution-value-cell">
@@ -1327,7 +1323,7 @@
         {{-- Footer --}}
         <div class="summary-footer">
             <div class="summary-footer-date">
-                Generated on {{ now()->format('F j, Y \a\t g:i A') }}
+                Generated on {{ $generatedAt->format('F j, Y \a\t g:i A') }}
             </div>
             <div class="summary-footer-tagline">
                 "The journey of a thousand miles begins with a single step" 🌍

--- a/resources/views/trip-pdf.blade.php
+++ b/resources/views/trip-pdf.blade.php
@@ -668,6 +668,216 @@
             font-size: 11px;
             color: #6b7280;
         }
+        
+        /* Summary Page Styles */
+        .summary-page {
+            page-break-before: always;
+            padding: 40px;
+            min-height: 90vh;
+        }
+        
+        .summary-header {
+            margin-bottom: 30px;
+            padding-bottom: 20px;
+            border-bottom: 3px solid var(--primary);
+        }
+        
+        .summary-title {
+            font-size: 42px;
+            font-weight: 800;
+            color: var(--dark);
+            margin-bottom: 10px;
+        }
+        
+        .summary-subtitle {
+            font-size: 14px;
+            color: #6b7280;
+            font-weight: 500;
+        }
+        
+        .summary-stats-grid {
+            display: table;
+            width: 100%;
+            margin-bottom: 30px;
+            border-spacing: 15px 0;
+        }
+        
+        .summary-stat-row {
+            display: table-row;
+        }
+        
+        .summary-stat-card {
+            display: table-cell;
+            width: 33.333%;
+            padding: 20px;
+            background: linear-gradient(135deg, rgba(37, 99, 235, 0.08) 0%, rgba(37, 99, 235, 0.03) 100%);
+            border-radius: 12px;
+            text-align: center;
+            border: 2px solid rgba(37, 99, 235, 0.1);
+        }
+        
+        .summary-stat-icon {
+            font-size: 32px;
+            margin-bottom: 10px;
+        }
+        
+        .summary-stat-value {
+            font-size: 32px;
+            font-weight: 800;
+            color: var(--primary);
+            margin-bottom: 5px;
+        }
+        
+        .summary-stat-label {
+            font-size: 12px;
+            color: #6b7280;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+        
+        .summary-section {
+            margin-bottom: 30px;
+            page-break-inside: avoid;
+        }
+        
+        .summary-section-title {
+            font-size: 20px;
+            font-weight: 700;
+            color: var(--dark);
+            margin-bottom: 15px;
+            padding-bottom: 10px;
+            border-bottom: 2px solid var(--border);
+        }
+        
+        .summary-tour-breakdown {
+            margin-bottom: 15px;
+        }
+        
+        .summary-tour-item {
+            display: table;
+            width: 100%;
+            margin-bottom: 15px;
+            padding: 15px;
+            background: white;
+            border-radius: 8px;
+            border-left: 4px solid var(--primary);
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+            page-break-inside: avoid;
+        }
+        
+        .summary-tour-icon-cell {
+            display: table-cell;
+            width: 40px;
+            vertical-align: middle;
+            font-size: 24px;
+        }
+        
+        .summary-tour-info-cell {
+            display: table-cell;
+            vertical-align: middle;
+            padding-left: 15px;
+        }
+        
+        .summary-tour-name {
+            font-size: 14px;
+            font-weight: 700;
+            color: var(--dark);
+            margin-bottom: 5px;
+        }
+        
+        .summary-tour-stats {
+            font-size: 10px;
+            color: #6b7280;
+        }
+        
+        .summary-tour-stat-item {
+            display: inline-block;
+            margin-right: 15px;
+        }
+        
+        .summary-distribution {
+            margin-top: 10px;
+        }
+        
+        .summary-distribution-item {
+            display: table;
+            width: 100%;
+            margin-bottom: 12px;
+            page-break-inside: avoid;
+        }
+        
+        .summary-distribution-label-cell {
+            display: table-cell;
+            width: 30%;
+            vertical-align: middle;
+            font-size: 11px;
+            color: #4b5563;
+            font-weight: 600;
+        }
+        
+        .summary-distribution-bar-cell {
+            display: table-cell;
+            vertical-align: middle;
+            padding-left: 10px;
+            padding-right: 10px;
+        }
+        
+        .summary-distribution-value-cell {
+            display: table-cell;
+            width: 50px;
+            text-align: right;
+            vertical-align: middle;
+            font-size: 11px;
+            color: #6b7280;
+            font-weight: 600;
+        }
+        
+        .summary-progress-bar-bg {
+            width: 100%;
+            height: 20px;
+            background: #f3f4f6;
+            border-radius: 10px;
+            overflow: hidden;
+            position: relative;
+        }
+        
+        .summary-progress-bar-fill {
+            height: 100%;
+            background: linear-gradient(90deg, var(--primary) 0%, var(--secondary) 100%);
+            border-radius: 10px;
+            transition: width 0.3s ease;
+        }
+        
+        .summary-empty-state {
+            padding: 30px;
+            text-align: center;
+            color: #9ca3af;
+            font-size: 12px;
+            background: #f9fafb;
+            border-radius: 8px;
+            border: 2px dashed #e5e7eb;
+        }
+        
+        .summary-footer {
+            margin-top: 40px;
+            padding-top: 20px;
+            border-top: 2px solid var(--border);
+            text-align: center;
+        }
+        
+        .summary-footer-date {
+            font-size: 10px;
+            color: #6b7280;
+            margin-bottom: 10px;
+        }
+        
+        .summary-footer-tagline {
+            font-size: 12px;
+            color: var(--primary);
+            font-weight: 600;
+            font-style: italic;
+        }
     </style>
 </head>
 <body>
@@ -986,5 +1196,143 @@
             </div>
         </div>
     @endforeach
+
+    {{-- Summary Page --}}
+    <div class="summary-page">
+        <div class="summary-header">
+            <h1 class="summary-title">Trip Summary</h1>
+            <p class="summary-subtitle">Your travel statistics and highlights</p>
+        </div>
+        
+        {{-- Key Statistics --}}
+        <div class="summary-stats-grid">
+            <div class="summary-stat-row">
+                <div class="summary-stat-card">
+                    <div class="summary-stat-icon">📍</div>
+                    <div class="summary-stat-value">{{ $summaryStats['totalLocations'] }}</div>
+                    <div class="summary-stat-label">Total Locations</div>
+                </div>
+                
+                <div class="summary-stat-card">
+                    <div class="summary-stat-icon">🗺️</div>
+                    <div class="summary-stat-value">{{ $summaryStats['totalTours'] }}</div>
+                    <div class="summary-stat-label">Tours</div>
+                </div>
+                
+                <div class="summary-stat-card">
+                    <div class="summary-stat-icon">⏱️</div>
+                    <div class="summary-stat-value">{{ number_format($summaryStats['totalDuration'], 1) }}</div>
+                    <div class="summary-stat-label">Total Hours</div>
+                </div>
+            </div>
+        </div>
+        
+        <div class="summary-stats-grid">
+            <div class="summary-stat-row">
+                <div class="summary-stat-card">
+                    <div class="summary-stat-icon">🚗</div>
+                    <div class="summary-stat-value">{{ number_format($summaryStats['totalDistance'], 1) }}</div>
+                    <div class="summary-stat-label">Kilometers</div>
+                </div>
+                
+                <div class="summary-stat-card">
+                    <div class="summary-stat-icon">🏛️</div>
+                    <div class="summary-stat-value">{{ $summaryStats['unescoCount'] }}</div>
+                    <div class="summary-stat-label">UNESCO Sites</div>
+                </div>
+                
+                <div class="summary-stat-card">
+                    <div class="summary-stat-icon">📌</div>
+                    <div class="summary-stat-value">{{ count($summaryStats['markerTypeDistribution']) }}</div>
+                    <div class="summary-stat-label">Marker Types</div>
+                </div>
+            </div>
+        </div>
+        
+        {{-- Tour Breakdown --}}
+        @if(!empty($summaryStats['tourBreakdown']))
+            <div class="summary-section">
+                <h2 class="summary-section-title">Tour Breakdown</h2>
+                <div class="summary-tour-breakdown">
+                    @foreach($summaryStats['tourBreakdown'] as $tourItem)
+                        <div class="summary-tour-item">
+                            <div class="summary-tour-icon-cell">🗺️</div>
+                            <div class="summary-tour-info-cell">
+                                <div class="summary-tour-name">{{ $tourItem['name'] }}</div>
+                                <div class="summary-tour-stats">
+                                    <span class="summary-tour-stat-item">📍 {{ $tourItem['markerCount'] }} {{ $tourItem['markerCount'] == 1 ? 'location' : 'locations' }}</span>
+                                    @if($tourItem['duration'] > 0)
+                                        <span class="summary-tour-stat-item">⏱️ {{ number_format($tourItem['duration'], 1) }}h</span>
+                                    @endif
+                                    @if($tourItem['distance'] > 0)
+                                        <span class="summary-tour-stat-item">🚗 {{ number_format($tourItem['distance'], 1) }}km</span>
+                                    @endif
+                                </div>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        @endif
+        
+        {{-- Marker Type Distribution --}}
+        @if(!empty($summaryStats['markerTypeDistribution']))
+            <div class="summary-section">
+                <h2 class="summary-section-title">Marker Type Distribution</h2>
+                <div class="summary-distribution">
+                    @php
+                        $maxCount = max(array_column($summaryStats['markerTypeDistribution'], 'count'));
+                    @endphp
+                    
+                    @foreach($summaryStats['markerTypeDistribution'] as $typeItem)
+                        <div class="summary-distribution-item">
+                            <div class="summary-distribution-label-cell">
+                                @if($typeItem['type'] === 'accommodation')
+                                    🏨 Accommodation
+                                @elseif($typeItem['type'] === 'restaurant')
+                                    🍽️ Restaurant
+                                @elseif($typeItem['type'] === 'activity')
+                                    🎯 Activity
+                                @elseif($typeItem['type'] === 'sight')
+                                    🏛️ Sight
+                                @elseif($typeItem['type'] === 'nature')
+                                    🌲 Nature
+                                @elseif($typeItem['type'] === 'transport')
+                                    🚗 Transport
+                                @else
+                                    📍 {{ ucfirst($typeItem['type']) }}
+                                @endif
+                            </div>
+                            <div class="summary-distribution-bar-cell">
+                                <div class="summary-progress-bar-bg">
+                                    <div class="summary-progress-bar-fill" style="width: {{ $maxCount > 0 ? ($typeItem['count'] / $maxCount * 100) : 0 }}%;"></div>
+                                </div>
+                            </div>
+                            <div class="summary-distribution-value-cell">
+                                {{ $typeItem['count'] }} ({{ $typeItem['percentage'] }}%)
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        @else
+            <div class="summary-section">
+                <h2 class="summary-section-title">Marker Type Distribution</h2>
+                <div class="summary-empty-state">
+                    No markers to display
+                </div>
+            </div>
+        @endif
+        
+        {{-- Footer --}}
+        <div class="summary-footer">
+            <div class="summary-footer-date">
+                Generated on {{ now()->format('F j, Y \a\t g:i A') }}
+            </div>
+            <div class="summary-footer-tagline">
+                "The journey of a thousand miles begins with a single step" 🌍
+            </div>
+        </div>
+    </div>
 </body>
 </html>

--- a/tests/Feature/TripPdfExportServiceTest.php
+++ b/tests/Feature/TripPdfExportServiceTest.php
@@ -669,7 +669,10 @@ test('calculateSummaryStats returns correct structure with comprehensive data', 
     $method = $reflection->getMethod('calculateSummaryStats');
     $method->setAccessible(true);
 
-    $stats = $method->invoke($this->pdfService, $trip, $toursData);
+    // Load tours with relationships (same as in the actual service)
+    $tours = $trip->tours()->with(['markers', 'routes'])->get();
+
+    $stats = $method->invoke($this->pdfService, $trip, $toursData, $tours);
 
     // Verify structure
     expect($stats)->toBeArray();
@@ -686,21 +689,21 @@ test('calculateSummaryStats returns correct structure with comprehensive data', 
     // Verify basic stats
     expect($stats['totalLocations'])->toBe(4);
     expect($stats['totalTours'])->toBe(2);
-    expect($stats['totalDuration'])->toBe(8.0); // 5.0 + 3.0
-    expect($stats['totalDistance'])->toBe(75.8); // (50500 + 25300) / 1000 = 75.8
+    expect(round($stats['totalDuration'], 1))->toBe(8.0); // 5.0 + 3.0
+    expect(round($stats['totalDistance'], 1))->toBe(75.8); // (50500 + 25300) / 1000 = 75.8
     expect($stats['unescoCount'])->toBe(1);
 
     // Verify tour breakdown
     expect($stats['tourBreakdown'])->toHaveCount(2);
     expect($stats['tourBreakdown'][0]['name'])->toBe('City Tour');
     expect($stats['tourBreakdown'][0]['markerCount'])->toBe(3);
-    expect($stats['tourBreakdown'][0]['duration'])->toBe(5.0);
-    expect($stats['tourBreakdown'][0]['distance'])->toBe(75.8);
+    expect(round($stats['tourBreakdown'][0]['duration'], 1))->toBe(5.0);
+    expect(round($stats['tourBreakdown'][0]['distance'], 1))->toBe(75.8);
 
     expect($stats['tourBreakdown'][1]['name'])->toBe('Nature Tour');
     expect($stats['tourBreakdown'][1]['markerCount'])->toBe(1);
-    expect($stats['tourBreakdown'][1]['duration'])->toBe(3.0);
-    expect($stats['tourBreakdown'][1]['distance'])->toBe(0.0);
+    expect(round($stats['tourBreakdown'][1]['duration'], 1))->toBe(3.0);
+    expect(round($stats['tourBreakdown'][1]['distance'], 1))->toBe(0.0);
 
     // Verify marker type distribution
     expect($stats['markerTypeDistribution'])->toHaveCount(4);
@@ -739,7 +742,10 @@ test('calculateSummaryStats handles trip with no markers', function () {
     $method = $reflection->getMethod('calculateSummaryStats');
     $method->setAccessible(true);
 
-    $stats = $method->invoke($this->pdfService, $trip, $toursData);
+    // Load tours with relationships (same as in the actual service)
+    $tours = $trip->tours()->with(['markers', 'routes'])->get();
+
+    $stats = $method->invoke($this->pdfService, $trip, $toursData, $tours);
 
     expect($stats['totalLocations'])->toBe(0);
     expect($stats['totalTours'])->toBe(0);
@@ -793,7 +799,10 @@ test('calculateSummaryStats handles tour without routes', function () {
     $method = $reflection->getMethod('calculateSummaryStats');
     $method->setAccessible(true);
 
-    $stats = $method->invoke($this->pdfService, $trip, $toursData);
+    // Load tours with relationships (same as in the actual service)
+    $tours = $trip->tours()->with(['markers', 'routes'])->get();
+
+    $stats = $method->invoke($this->pdfService, $trip, $toursData, $tours);
 
     expect($stats['totalLocations'])->toBe(1);
     expect($stats['totalTours'])->toBe(1);
@@ -845,7 +854,10 @@ test('calculateSummaryStats handles markers without estimated hours', function (
     $method = $reflection->getMethod('calculateSummaryStats');
     $method->setAccessible(true);
 
-    $stats = $method->invoke($this->pdfService, $trip, $toursData);
+    // Load tours with relationships (same as in the actual service)
+    $tours = $trip->tours()->with(['markers', 'routes'])->get();
+
+    $stats = $method->invoke($this->pdfService, $trip, $toursData, $tours);
 
     expect($stats['totalDuration'])->toBe(0.0);
     expect($stats['tourBreakdown'][0]['duration'])->toBe(0.0);
@@ -898,7 +910,10 @@ test('calculateSummaryStats handles multiple markers with same type', function (
     $method = $reflection->getMethod('calculateSummaryStats');
     $method->setAccessible(true);
 
-    $stats = $method->invoke($this->pdfService, $trip, $toursData);
+    // Load tours with relationships (same as in the actual service)
+    $tours = $trip->tours()->with(['markers', 'routes'])->get();
+
+    $stats = $method->invoke($this->pdfService, $trip, $toursData, $tours);
 
     expect($stats['totalLocations'])->toBe(8);
     expect($stats['markerTypeDistribution'])->toHaveCount(2);
@@ -961,7 +976,10 @@ test('calculateSummaryStats handles multiple UNESCO sites', function () {
     $method = $reflection->getMethod('calculateSummaryStats');
     $method->setAccessible(true);
 
-    $stats = $method->invoke($this->pdfService, $trip, $toursData);
+    // Load tours with relationships (same as in the actual service)
+    $tours = $trip->tours()->with(['markers', 'routes'])->get();
+
+    $stats = $method->invoke($this->pdfService, $trip, $toursData, $tours);
 
     expect($stats['unescoCount'])->toBe(3);
     expect($stats['totalLocations'])->toBe(5);


### PR DESCRIPTION
## Summary

This PR adds a comprehensive summary page at the end of PDF exports showing trip statistics and highlights.

Fixes #424

## Changes

### Backend (TripPdfExportService)

- Added `calculateSummaryStats()` method that computes:
  - Total locations, tours, duration, distance, UNESCO sites
  - Tour breakdown with metrics per tour (marker count, duration, distance)
  - Marker type distribution with counts and percentages
- Updated `prepareToursData()` to include tour ID for route distance calculations
- Modified `generatePdf()` to call `calculateSummaryStats()` and pass data to view

### Frontend (trip-pdf.blade.php)

- Added summary page section with:
  - Key statistics displayed in 6 stat cards (locations, tours, duration, distance, UNESCO sites, marker types)
  - Tour breakdown section listing all tours with their metrics
  - Marker type distribution with visual progress bars showing percentage breakdown
  - Footer with generation date and inspirational tagline
- Added comprehensive CSS styling:
  - Stat cards with gradient backgrounds and icons
  - Tour items with left border accents
  - Progress bars with gradient fills
  - Empty state handling for trips without data
  - Table-based layouts for DomPDF compatibility

### Tests

- Added 6 comprehensive unit tests for `calculateSummaryStats()`:
  - Test with complete trip data (markers, routes, UNESCO sites, multiple types)
  - Test with empty trip (no markers)
  - Test with tour without routes
  - Test with markers without estimated hours
  - Test with multiple markers of same type (distribution percentages)
  - Test with multiple UNESCO sites
- All tests use reflection to access private method
- All 600 tests passing

## How to Test

1. Create a trip with multiple tours, markers of different types, routes, and UNESCO sites
2. Export the trip as PDF
3. Verify the summary page appears at the end with:
   - Correct statistics (locations, tours, duration, distance, UNESCO count)
   - Tour breakdown showing all tours with their metrics
   - Marker type distribution showing percentage bars
4. Test edge cases:
   - Trip with no markers (should show zeros)
   - Tour without routes (distance should be 0)
   - Mixed marker types (percentages should add up to 100%)

## Screenshots

The summary page includes:
- 📊 Key statistics in colorful stat cards
- 🗺️ Tour breakdown with detailed metrics
- 📌 Marker type distribution with visual progress bars
- 🌍 Inspirational footer quote

## Notes

- Uses table-based layouts for DomPDF compatibility (no CSS Grid)
- Emojis used for universal icon support
- Progress bars use gradient fills for visual appeal
- All durations and distances properly formatted
- Handles edge cases gracefully (empty states)