### PR TITLE
feat: automated daily database backup with spatie/laravel-backup (#437)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -211,7 +211,7 @@ jobs:
             
             # Pre-deploy database backup
             echo "💾 Creating pre-deploy database backup..."
-            php artisan backup:run --only-db --no-interaction 2>/dev/null || echo "⚠️ Pre-deploy backup failed, continuing anyway"
+            php artisan backup:run --only-db --no-interaction >>pre-deploy-backup.log 2>&1 || echo "⚠️ Pre-deploy backup failed, continuing anyway (see pre-deploy-backup.log on server)"
             echo "✅ Pre-deploy backup done"
             
             # Entpacke das Deployment

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -209,6 +209,11 @@ jobs:
               cp .env .env.backup.$(date +%Y%m%d_%H%M%S)
             fi
             
+            # Pre-deploy database backup
+            echo "💾 Creating pre-deploy database backup..."
+            php artisan backup:run --only-db --no-interaction 2>/dev/null || echo "⚠️ Pre-deploy backup failed, continuing anyway"
+            echo "✅ Pre-deploy backup done"
+            
             # Entpacke das Deployment
             echo "📦 Extracting deployment package..."
             unzip -q -o deployment.zip

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -206,6 +206,11 @@ jobs:
               cp .env .env.backup.$(date +%Y%m%d_%H%M%S)
             fi
             
+            # Pre-deploy database backup
+            echo "💾 Creating pre-deploy database backup..."
+            php artisan backup:run --only-db --no-interaction 2>/dev/null || echo "⚠️ Pre-deploy backup failed, continuing anyway"
+            echo "✅ Pre-deploy backup done"
+            
             # Entpacke das Deployment
             echo "📦 Extracting deployment package..."
             unzip -q -o deployment.zip
@@ -246,6 +251,7 @@ jobs:
             # php artisan migrate --force
             
             echo "✅ Deployment completed successfully!"
+          SCRIPT
 
       - name: Create deployment summary
         if: success()

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -208,7 +208,7 @@ jobs:
             
             # Pre-deploy database backup
             echo "💾 Creating pre-deploy database backup..."
-            php artisan backup:run --only-db --no-interaction 2>/dev/null || echo "⚠️ Pre-deploy backup failed, continuing anyway"
+            php artisan backup:run --only-db --no-interaction >>pre-deploy-backup.log 2>&1 || echo "⚠️ Pre-deploy backup failed, continuing anyway (see pre-deploy-backup.log on server)"
             echo "✅ Pre-deploy backup done"
             
             # Entpacke das Deployment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,18 @@ jobs:
     name: Unit and Feature Tests
     runs-on: ubuntu-latest
 
+    services:
+      mariadb:
+        image: mariadb:11
+        env:
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_DATABASE: travel_map
+          MARIADB_USER: travel_map
+          MARIADB_PASSWORD: secret
+        ports:
+          - 3306:3306
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=5
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,7 +60,7 @@ jobs:
       - name: Build Assets
         run: npm run build
         env:
-          VITE_MAPBOX_ACCESS_TOKEN: pk.eyJ1IjoidGhlLWtvbGxlciIsImEiOiJjbWs5eHBobTMwcTUwM2dyMmdwMGVqenQ4In0.dSooQl188W3T2_dRLUsZMg
+          VITE_MAPBOX_ACCESS_TOKEN: pk.test-token-for-ci
 
       - name: Run Database Migrations
         run: php artisan migrate --force

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,7 +360,7 @@ If your application uses the `<Form>` component from Inertia, you can use Wayfin
   it('returns all', function () {
   $response = $this->postJson('/api/docs', []);
 
-            $response->assertSuccessful();
+              $response->assertSuccessful();
 
     });
     </code-snippet>
@@ -664,6 +664,8 @@ Replace `/path/to/prod` and `/path/to/dev` with the actual server paths for each
 ### Restore Procedure
 
 1. `php artisan backup:list` — list available backups
-2. Locate the desired `.zip` in `storage/app/<APP_NAME>/`
-3. Extract the `.zip` — it contains a `.sql` dump
-4. Restore: `mysql -u <user> -p <database> < dump.sql`
+2. Locate the desired `.zip` file on the backup disk (by default stored under `storage/app/backups/` — see `config/backup.php` and `BACKUP_NAME` env var for the exact folder name)
+3. Extract the `.zip` — it contains a database dump; the file type depends on your `DB_CONNECTION`
+4. Determine the active database connection from `.env` (`DB_CONNECTION`) and restore accordingly:
+    - **MariaDB/MySQL**: `mysql -h <host> -u <user> -p <database> < dump.sql`
+    - **SQLite**: Stop the app, back up the current `.sqlite` file, then replace `DB_DATABASE` with the `.sqlite` file from the backup and restore correct permissions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,7 +360,7 @@ If your application uses the `<Form>` component from Inertia, you can use Wayfin
   it('returns all', function () {
   $response = $this->postJson('/api/docs', []);
 
-          $response->assertSuccessful();
+            $response->assertSuccessful();
 
     });
     </code-snippet>
@@ -645,3 +645,25 @@ Before creating a pull request, run ALL of the following:
 - This workflow applies ONLY when working on GitHub issues
 - For general questions, code reviews, or exploratory work, use normal development flow
 - Always ask the user if uncertain whether to follow the full workflow
+
+## Database Backup
+
+Automated daily backups are configured via `spatie/laravel-backup`. Backups run daily and are retained for 14 days.
+
+### Cronjob Setup (manual, once per environment in all-inkl.com KAS)
+
+The Laravel scheduler must be triggered every minute via a server-side cronjob. Set this up once per environment in all-inkl.com KAS:
+
+```
+* * * * * /usr/bin/php /path/to/prod/artisan schedule:run >> /dev/null 2>&1
+* * * * * /usr/bin/php /path/to/dev/artisan schedule:run >> /dev/null 2>&1
+```
+
+Replace `/path/to/prod` and `/path/to/dev` with the actual server paths for each environment.
+
+### Restore Procedure
+
+1. `php artisan backup:list` — list available backups
+2. Locate the desired `.zip` in `storage/app/<APP_NAME>/`
+3. Extract the `.zip` — it contains a `.sql` dump
+4. Restore: `mysql -u <user> -p <database> < dump.sql`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,7 +360,7 @@ If your application uses the `<Form>` component from Inertia, you can use Wayfin
   it('returns all', function () {
   $response = $this->postJson('/api/docs', []);
 
-              $response->assertSuccessful();
+                $response->assertSuccessful();
 
     });
     </code-snippet>
@@ -592,11 +592,14 @@ Before creating a pull request, run ALL of the following:
 
 #### 4. Create Pull Request
 
+> **CRITICAL**: Every PR MUST be linked to its issue. Always include a closing keyword in the PR description. This is mandatory, no exceptions.
+
 - Push branch to remote: `git push origin <branch-name>`
 - Create pull request using GitHub CLI or web interface
 - **CRITICAL**: Link the PR to the issue using GitHub keywords in PR description:
     - Use: "Closes #123" or "Fixes #123" or "Resolves #123"
     - This automatically links and closes the issue when PR is merged
+    - Example PR body line: `Closes #437`
 - PR title should be clear and reference the issue number
 - PR description should include:
     - Summary of changes

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "laravel/wayfinder": "^0.1.9",
         "league/commonmark": "^2.8",
         "opcodesio/log-viewer": "^3.21",
-        "spatie/laravel-backup": "*",
+        "spatie/laravel-backup": "^10.0",
         "unsplash/unsplash": "^3.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "laravel/wayfinder": "^0.1.9",
         "league/commonmark": "^2.8",
         "opcodesio/log-viewer": "^3.21",
+        "spatie/laravel-backup": "*",
         "unsplash/unsplash": "^3.2"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bddf605c0cfe480bd2d65881157368ad",
+    "content-hash": "fc922fe25637f1ee0cd88e762abb08eb",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -4395,6 +4395,367 @@
                 "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v9.1.0"
             },
             "time": "2025-09-14T07:37:21+00:00"
+        },
+        {
+            "name": "spatie/db-dumper",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/db-dumper.git",
+                "reference": "f6242fc0f9673cf2b3effda80c3b697cf37531a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/f6242fc0f9673cf2b3effda80c3b697cf37531a5",
+                "reference": "f6242fc0f9673cf2b3effda80c3b697cf37531a5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.4",
+                "symfony/process": "^7.0|^8.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^4.0",
+                "phpstan/phpstan": "^2.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\DbDumper\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Dump databases",
+            "homepage": "https://github.com/spatie/db-dumper",
+            "keywords": [
+                "database",
+                "db-dumper",
+                "dump",
+                "mysqldump",
+                "spatie"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/db-dumper/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-15T22:15:48+00:00"
+        },
+        {
+            "name": "spatie/laravel-backup",
+            "version": "10.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-backup.git",
+                "reference": "222bbe7cce2de973d3538d14659061075525b5dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/222bbe7cce2de973d3538d14659061075525b5dd",
+                "reference": "222bbe7cce2de973d3538d14659061075525b5dd",
+                "shasum": ""
+            },
+            "require": {
+                "ext-zip": "^1.14.0",
+                "illuminate/console": "^12.40|^13.0",
+                "illuminate/contracts": "^12.40|^13.0",
+                "illuminate/events": "^12.40|^13.0",
+                "illuminate/filesystem": "^12.40|^13.0",
+                "illuminate/notifications": "^12.40|^13.0",
+                "illuminate/support": "^12.40|^13.0",
+                "league/flysystem": "^3.30.2",
+                "php": "^8.4",
+                "spatie/db-dumper": "^4.0",
+                "spatie/laravel-package-tools": "^1.92.7",
+                "spatie/laravel-signal-aware-command": "^2.1",
+                "spatie/temporary-directory": "^2.3",
+                "symfony/console": "^7.3.6|^8.0",
+                "symfony/finder": "^7.3.5|^8.0"
+            },
+            "require-dev": {
+                "composer-runtime-api": "^2.0",
+                "ext-pcntl": "*",
+                "larastan/larastan": "^3.8",
+                "laravel/slack-notification-channel": "^3.7",
+                "league/flysystem-aws-s3-v3": "^3.30.1",
+                "mockery/mockery": "^1.6.12",
+                "orchestra/testbench": "^10.8|^11.0",
+                "pestphp/pest": "^4.1.5",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan-deprecation-rules": "^2.0.3",
+                "phpstan/phpstan-phpunit": "^2.0.8",
+                "rector/rector": "^2.2.8"
+            },
+            "suggest": {
+                "laravel/slack-notification-channel": "Required for sending notifications via Slack"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Backup\\BackupServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Helpers/functions.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Backup\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A Laravel package to backup your application",
+            "homepage": "https://github.com/spatie/laravel-backup",
+            "keywords": [
+                "backup",
+                "database",
+                "laravel-backup",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-backup/issues",
+                "source": "https://github.com/spatie/laravel-backup/tree/10.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/spatie",
+                    "type": "github"
+                },
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-02-22T08:29:02+00:00"
+        },
+        {
+            "name": "spatie/laravel-package-tools",
+            "version": "1.93.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-package-tools.git",
+                "reference": "0d097bce95b2bf6802fb1d83e1e753b0f5a948e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/0d097bce95b2bf6802fb1d83e1e753b0f5a948e7",
+                "reference": "0d097bce95b2bf6802fb1d83e1e753b0f5a948e7",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.5",
+                "orchestra/testbench": "^8.0|^9.2|^10.0|^11.0",
+                "pestphp/pest": "^2.1|^3.1|^4.0",
+                "phpunit/php-code-coverage": "^10.0|^11.0|^12.0",
+                "phpunit/phpunit": "^10.5|^11.5|^12.5",
+                "spatie/pest-plugin-test-time": "^2.2|^3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\LaravelPackageTools\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Tools for creating Laravel packages",
+            "homepage": "https://github.com/spatie/laravel-package-tools",
+            "keywords": [
+                "laravel-package-tools",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-package-tools/issues",
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.93.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-21T12:49:54+00:00"
+        },
+        {
+            "name": "spatie/laravel-signal-aware-command",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-signal-aware-command.git",
+                "reference": "54dcc1efd152bfb3eb0faf56a5fc28569b864b5d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-signal-aware-command/zipball/54dcc1efd152bfb3eb0faf56a5fc28569b864b5d",
+                "reference": "54dcc1efd152bfb3eb0faf56a5fc28569b864b5d",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "spatie/laravel-package-tools": "^1.4.3",
+                "symfony/console": "^7.0|^8.0"
+            },
+            "require-dev": {
+                "brianium/paratest": "^6.2|^7.0",
+                "ext-pcntl": "*",
+                "nunomaduro/collision": "^5.3|^6.0|^7.0|^8.0",
+                "orchestra/testbench": "^9.0|^10.0",
+                "pestphp/pest-plugin-laravel": "^1.3|^2.0|^3.0",
+                "phpunit/phpunit": "^9.5|^10|^11",
+                "spatie/laravel-ray": "^1.17"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Signal": "Spatie\\SignalAwareCommand\\Facades\\Signal"
+                    },
+                    "providers": [
+                        "Spatie\\SignalAwareCommand\\SignalAwareCommandServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\SignalAwareCommand\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Handle signals in artisan commands",
+            "homepage": "https://github.com/spatie/laravel-signal-aware-command",
+            "keywords": [
+                "laravel",
+                "laravel-signal-aware-command",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-signal-aware-command/issues",
+                "source": "https://github.com/spatie/laravel-signal-aware-command/tree/2.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-22T08:16:31+00:00"
+        },
+        {
+            "name": "spatie/temporary-directory",
+            "version": "2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/temporary-directory.git",
+                "reference": "662e481d6ec07ef29fd05010433428851a42cd07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/662e481d6ec07ef29fd05010433428851a42cd07",
+                "reference": "662e481d6ec07ef29fd05010433428851a42cd07",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\TemporaryDirectory\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily create, use and destroy temporary directories",
+            "homepage": "https://github.com/spatie/temporary-directory",
+            "keywords": [
+                "php",
+                "spatie",
+                "temporary-directory"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/temporary-directory/issues",
+                "source": "https://github.com/spatie/temporary-directory/tree/2.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-01-12T07:42:22+00:00"
         },
         {
             "name": "symfony/clock",

--- a/config/backup.php
+++ b/config/backup.php
@@ -7,7 +7,7 @@ return [
          * The name of this application. You can use this name to monitor
          * the backups.
          */
-        'name' => env('APP_NAME', 'laravel-backup'),
+        'name' => env('BACKUP_NAME', 'backups'),
 
         'source' => [
             'files' => [
@@ -270,7 +270,7 @@ return [
      */
     'monitor_backups' => [
         [
-            'name' => env('APP_NAME', 'laravel-backup'),
+            'name' => env('BACKUP_NAME', 'backups'),
             'disks' => ['local'],
             'health_checks' => [
                 \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays::class => 2,

--- a/config/backup.php
+++ b/config/backup.php
@@ -1,0 +1,357 @@
+<?php
+
+return [
+
+    'backup' => [
+        /*
+         * The name of this application. You can use this name to monitor
+         * the backups.
+         */
+        'name' => env('APP_NAME', 'laravel-backup'),
+
+        'source' => [
+            'files' => [
+                /*
+                 * The list of directories and files that will be included in the backup.
+                 */
+                'include' => [],
+
+                /*
+                 * These directories and files will be excluded from the backup.
+                 *
+                 * Directories used by the backup process will automatically be excluded.
+                 */
+                'exclude' => [
+                    base_path('vendor'),
+                    base_path('node_modules'),
+                    storage_path('framework'),
+                ],
+
+                /*
+                 * Determines if symlinks should be followed.
+                 */
+                'follow_links' => false,
+
+                /*
+                 * Determines if it should avoid unreadable folders.
+                 */
+                'ignore_unreadable_directories' => false,
+
+                /*
+                 * This path is used to make directories in resulting zip-file relative
+                 * Set to `null` to include complete absolute path
+                 * Example: base_path()
+                 */
+                'relative_path' => null,
+            ],
+
+            /*
+             * The names of the connections to the databases that should be backed up
+             * MySQL, PostgreSQL, SQLite and Mongo databases are supported.
+             *
+             * The content of the database dump may be customized for each connection
+             * by adding a 'dump' key to the connection settings in config/database.php.
+             * E.g.
+             * 'mysql' => [
+             *       ...
+             *      'dump' => [
+             *           'exclude_tables' => [
+             *                'table_to_exclude_from_backup',
+             *                'another_table_to_exclude'
+             *            ]
+             *       ],
+             * ],
+             *
+             * If you are using only InnoDB tables on a MySQL server, you can
+             * also supply the useSingleTransaction option to avoid table locking.
+             *
+             * E.g.
+             * 'mysql' => [
+             *       ...
+             *      'dump' => [
+             *           'useSingleTransaction' => true,
+             *       ],
+             * ],
+             *
+             * For a complete list of available customization options, see https://github.com/spatie/db-dumper
+             */
+            'databases' => [
+                env('DB_CONNECTION', 'mysql'),
+            ],
+        ],
+
+        /*
+         * The database dump can be compressed to decrease disk space usage.
+         *
+         * Out of the box Laravel-backup supplies
+         * Spatie\DbDumper\Compressors\GzipCompressor::class.
+         *
+         * You can also create custom compressor. More info on that here:
+         * https://github.com/spatie/db-dumper#using-compression
+         *
+         * If you do not want any compressor at all, set it to null.
+         */
+        'database_dump_compressor' => null,
+
+        /*
+         * If specified, the database dumped file name will contain a timestamp (e.g.: 'Y-m-d-H-i-s').
+         */
+        'database_dump_file_timestamp_format' => null,
+
+        /*
+         * The base of the dump filename, either 'database' or 'connection'
+         *
+         * If 'database' (default), the dumped filename will contain the database name.
+         * If 'connection', the dumped filename will contain the connection name.
+         */
+        'database_dump_filename_base' => 'database',
+
+        /*
+         * The file extension used for the database dump files.
+         *
+         * If not specified, the file extension will be .archive for MongoDB and .sql for all other databases
+         * The file extension should be specified without a leading .
+         */
+        'database_dump_file_extension' => '',
+
+        'destination' => [
+            /*
+             * The compression algorithm to be used for creating the zip archive.
+             *
+             * If backing up only database, you may choose gzip compression for db dump and no compression at zip.
+             *
+             * Some common algorithms are listed below:
+             * ZipArchive::CM_STORE (no compression at all; set 0 as compression level)
+             * ZipArchive::CM_DEFAULT
+             * ZipArchive::CM_DEFLATE
+             * ZipArchive::CM_BZIP2
+             * ZipArchive::CM_XZ
+             *
+             * For more check https://www.php.net/manual/zip.constants.php and confirm it's supported by your system.
+             */
+            'compression_method' => ZipArchive::CM_DEFAULT,
+
+            /*
+             * The compression level corresponding to the used algorithm; an integer between 0 and 9.
+             *
+             * Check supported levels for the chosen algorithm, usually 1 means the fastest and weakest compression,
+             * while 9 the slowest and strongest one.
+             *
+             * Setting of 0 for some algorithms may switch to the strongest compression.
+             */
+            'compression_level' => 9,
+
+            /*
+             * The filename prefix used for the backup zip file.
+             */
+            'filename_prefix' => '',
+
+            /*
+             * The disk names on which the backups will be stored.
+             */
+            'disks' => [
+                'local',
+            ],
+
+            /*
+             * Determines whether to allow backups to continue when some targets fail instead of failing completely.
+             */
+            'continue_on_failure' => false,
+        ],
+
+        /*
+         * The directory where the temporary files will be stored.
+         */
+        'temporary_directory' => storage_path('app/backup-temp'),
+
+        /*
+         * The password to be used for archive encryption.
+         * Set to `null` to disable encryption.
+         */
+        'password' => env('BACKUP_ARCHIVE_PASSWORD'),
+
+        /*
+         * The encryption algorithm to be used for archive encryption.
+         * Set to 'none' to disable encryption.
+         *
+         * Supported: 'none', 'default', 'aes128', 'aes192', 'aes256'
+         *
+         * When set to 'default', we'll use AES-256 if available on your system.
+         */
+        'encryption' => 'default',
+
+        /*
+         * After creating the zip, verify it can be opened and contains files.
+         * Recommended for critical backups but adds a small overhead.
+         */
+        'verify_backup' => false,
+
+        /*
+         * The number of attempts, in case the backup command encounters an exception
+         */
+        'tries' => 1,
+
+        /*
+         * The number of seconds to wait before attempting a new backup if the previous try failed
+         * Set to `0` for none
+         */
+        'retry_delay' => 0,
+    ],
+
+    /*
+     * You can get notified when specific events occur. Out of the box you can use 'mail' and 'slack'.
+     * For Slack you need to install laravel/slack-notification-channel.
+     *
+     * You can also use your own notification classes, just make sure the class is named after one of
+     * the `Spatie\Backup\Notifications\Notifications` classes.
+     */
+    'notifications' => [
+        'notifications' => [
+            \Spatie\Backup\Notifications\Notifications\BackupHasFailedNotification::class => ['mail'],
+            \Spatie\Backup\Notifications\Notifications\UnhealthyBackupWasFoundNotification::class => ['mail'],
+            \Spatie\Backup\Notifications\Notifications\CleanupHasFailedNotification::class => ['mail'],
+        ],
+
+        /*
+         * Here you can specify the notifiable to which the notifications should be sent. The default
+         * notifiable will use the variables specified in this config file.
+         */
+        'notifiable' => \Spatie\Backup\Notifications\Notifiable::class,
+
+        'mail' => [
+            'to' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
+
+            'from' => [
+                'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
+                'name' => env('MAIL_FROM_NAME', 'Example'),
+            ],
+        ],
+
+        'slack' => [
+            'webhook_url' => '',
+
+            /*
+             * If this is set to null the default channel of the webhook will be used.
+             */
+            'channel' => null,
+
+            'username' => null,
+
+            'icon' => null,
+        ],
+
+        'discord' => [
+            'webhook_url' => '',
+
+            /*
+             * If this is an empty string, the name field on the webhook will be used.
+             */
+            'username' => '',
+
+            /*
+             * If this is an empty string, the avatar on the webhook will be used.
+             */
+            'avatar_url' => '',
+        ],
+
+        /*
+         * A generic webhook channel that POSTs JSON to a URL.
+         * Useful for Mattermost, Microsoft Teams, or custom integrations.
+         */
+        'webhook' => [
+            'url' => '',
+        ],
+    ],
+
+    /*
+     * Here you can specify which backups should be monitored.
+     * If a backup does not meet the specified requirements the
+     * UnHealthyBackupWasFound event will be fired.
+     */
+    'monitor_backups' => [
+        [
+            'name' => env('APP_NAME', 'laravel-backup'),
+            'disks' => ['local'],
+            'health_checks' => [
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays::class => 2,
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes::class => 512,
+            ],
+        ],
+
+        /*
+        [
+            'name' => 'name of the second app',
+            'disks' => ['local', 's3'],
+            'health_checks' => [
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays::class => 1,
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes::class => 5000,
+            ],
+        ],
+        */
+    ],
+
+    'cleanup' => [
+        /*
+         * The strategy that will be used to cleanup old backups. The default strategy
+         * will keep all backups for a certain amount of days. After that period only
+         * a daily backup will be kept. After that period only weekly backups will
+         * be kept and so on.
+         *
+         * No matter how you configure it the default strategy will never
+         * delete the newest backup.
+         */
+        'strategy' => \Spatie\Backup\Tasks\Cleanup\Strategies\DefaultStrategy::class,
+
+        'default_strategy' => [
+            /*
+             * The number of days for which backups must be kept.
+             */
+            'keep_all_backups_for_days' => 14,
+
+            /*
+             * After the "keep_all_backups_for_days" period is over, the most recent backup
+             * of that day will be kept. Older backups within the same day will be removed.
+             * If you create backups only once a day, no backups will be removed yet.
+             */
+            'keep_daily_backups_for_days' => 0,
+
+            /*
+             * After the "keep_daily_backups_for_days" period is over, the most recent backup
+             * of that week will be kept. Older backups within the same week will be removed.
+             * If you create backups only once a week, no backups will be removed yet.
+             */
+            'keep_weekly_backups_for_weeks' => 0,
+
+            /*
+             * After the "keep_weekly_backups_for_weeks" period is over, the most recent backup
+             * of that month will be kept. Older backups within the same month will be removed.
+             */
+            'keep_monthly_backups_for_months' => 0,
+
+            /*
+             * After the "keep_monthly_backups_for_months" period is over, the most recent backup
+             * of that year will be kept. Older backups within the same year will be removed.
+             */
+            'keep_yearly_backups_for_years' => 0,
+
+            /*
+             * After cleaning up the backups remove the oldest backup until
+             * this amount of megabytes has been reached.
+             * Set null for unlimited size.
+             */
+            'delete_oldest_backups_when_using_more_megabytes_than' => 512,
+        ],
+
+        /*
+         * The number of attempts, in case the cleanup command encounters an exception
+         */
+        'tries' => 1,
+
+        /*
+         * The number of seconds to wait before attempting a new cleanup if the previous try failed
+         * Set to `0` for none
+         */
+        'retry_delay' => 0,
+    ],
+
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "travel-map",
             "dependencies": {
                 "@fortawesome/fontawesome-free": "^7.1.0",
                 "@headlessui/react": "^2.2.0",

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,11 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Schedule::command('backup:clean')->dailyAt('01:00');
+Schedule::command('backup:run --only-db')->dailyAt('02:00');

--- a/tests/Feature/BackupConfigTest.php
+++ b/tests/Feature/BackupConfigTest.php
@@ -11,6 +11,10 @@ it('only backs up the database (no files)', function () {
     expect(config('backup.backup.source.files.include'))->toBe([]);
 });
 
+it('uses a stable BACKUP_NAME env var for the backup name', function () {
+    expect(config('backup.backup.name'))->toBe(env('BACKUP_NAME', 'backups'));
+});
+
 it('stores backups on the local disk', function () {
     expect(config('backup.backup.destination.disks'))->toBe(['local']);
 });

--- a/tests/Feature/BackupConfigTest.php
+++ b/tests/Feature/BackupConfigTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Spatie\Backup\Notifications\Notifications\BackupHasFailedNotification;
+use Spatie\Backup\Notifications\Notifications\CleanupHasFailedNotification;
+use Spatie\Backup\Notifications\Notifications\UnhealthyBackupWasFoundNotification;
+use Spatie\Backup\Tasks\Cleanup\Strategies\DefaultStrategy;
+use Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays;
+use Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes;
+
+it('only backs up the database (no files)', function () {
+    expect(config('backup.backup.source.files.include'))->toBe([]);
+});
+
+it('stores backups on the local disk', function () {
+    expect(config('backup.backup.destination.disks'))->toBe(['local']);
+});
+
+it('only notifies on failure events', function () {
+    $notifications = array_keys(config('backup.notifications.notifications'));
+
+    expect($notifications)
+        ->toContain(BackupHasFailedNotification::class)
+        ->toContain(UnhealthyBackupWasFoundNotification::class)
+        ->toContain(CleanupHasFailedNotification::class)
+        ->toHaveCount(3);
+});
+
+it('sends failure notifications to MAIL_FROM_ADDRESS', function () {
+    expect(config('backup.notifications.mail.to'))->toBe(env('MAIL_FROM_ADDRESS', 'hello@example.com'));
+});
+
+it('uses the correct health check thresholds', function () {
+    $healthChecks = config('backup.monitor_backups.0.health_checks');
+
+    expect($healthChecks)
+        ->toHaveKey(MaximumAgeInDays::class)
+        ->toHaveKey(MaximumStorageInMegabytes::class);
+
+    expect($healthChecks[MaximumAgeInDays::class])->toBe(2);
+    expect($healthChecks[MaximumStorageInMegabytes::class])->toBe(512);
+});
+
+it('uses the default cleanup strategy with 14-day retention', function () {
+    expect(config('backup.cleanup.strategy'))->toBe(DefaultStrategy::class);
+    expect(config('backup.cleanup.default_strategy.keep_all_backups_for_days'))->toBe(14);
+});
+
+it('disables all other retention periods', function () {
+    $strategy = config('backup.cleanup.default_strategy');
+
+    expect($strategy['keep_daily_backups_for_days'])->toBe(0)
+        ->and($strategy['keep_weekly_backups_for_weeks'])->toBe(0)
+        ->and($strategy['keep_monthly_backups_for_months'])->toBe(0)
+        ->and($strategy['keep_yearly_backups_for_years'])->toBe(0);
+});
+
+it('limits storage to 512 MB', function () {
+    expect(config('backup.cleanup.default_strategy.delete_oldest_backups_when_using_more_megabytes_than'))->toBe(512);
+});
+
+it('schedules backup commands via the Laravel scheduler', function () {
+    $schedule = app(\Illuminate\Console\Scheduling\Schedule::class);
+
+    $commands = collect($schedule->events())
+        ->map(fn ($event) => $event->command ?? '')
+        ->filter(fn ($cmd) => str_contains($cmd, 'backup:'))
+        ->values()
+        ->all();
+
+    expect(collect($commands)->contains(fn ($cmd) => str_contains($cmd, 'backup:clean')))->toBeTrue();
+    expect(collect($commands)->contains(fn ($cmd) => str_contains($cmd, 'backup:run')))->toBeTrue();
+});


### PR DESCRIPTION
## Summary

- Installs and configures `spatie/laravel-backup` for automated daily database-only backups
- Backups are stored locally (`storage/app/<APP_NAME>/`), retained for 14 days, capped at 512 MB
- Pre-deploy DB snapshot added to both `deploy-prod.yml` and `deploy-dev.yml` (runs before unzip)
- Failure-only email notifications sent to `MAIL_FROM_ADDRESS`
- Health checks: `MaximumAgeInDays=2`, `MaximumStorageInMegabytes=512`
- Cronjob setup and restore procedure documented in `AGENTS.md`

## How to Test

1. Set up the scheduler cronjob as described in `AGENTS.md`
2. Run `php artisan backup:run --only-db` manually and verify a zip appears in `storage/app/<APP_NAME>/`
3. Run `php artisan backup:list` to confirm the backup is listed as healthy
4. Run `php artisan test --compact tests/Feature/BackupConfigTest.php` — all 9 tests should pass

## Breaking Changes / Migrations

None. The scheduler requires a one-time cronjob setup on the server (documented in `AGENTS.md`).

Closes #437