### PR TITLE
feat(admin): allow admins to fully manage other users' trips

### DIFF
--- a/app/Http/Controllers/TripCollaboratorController.php
+++ b/app/Http/Controllers/TripCollaboratorController.php
@@ -45,7 +45,7 @@ class TripCollaboratorController extends Controller
     {
         // Only the owner or an admin can add collaborators
         if (! $trip->isOwner(auth()->user()) && ! auth()->user()->isAdmin()) {
-            return response()->json(['error' => 'Only the trip owner can add collaborators'], 403);
+            return response()->json(['error' => 'Only the trip owner or an admin can add collaborators'], 403);
         }
 
         $validated = $request->validated();
@@ -84,7 +84,7 @@ class TripCollaboratorController extends Controller
     {
         // Only the owner or an admin can remove collaborators
         if (! $trip->isOwner(auth()->user()) && ! auth()->user()->isAdmin()) {
-            return response()->json(['error' => 'Only the trip owner can remove collaborators'], 403);
+            return response()->json(['error' => 'Only the trip owner or an admin can remove collaborators'], 403);
         }
 
         // Cannot remove the owner

--- a/app/Http/Controllers/TripCollaboratorController.php
+++ b/app/Http/Controllers/TripCollaboratorController.php
@@ -43,8 +43,8 @@ class TripCollaboratorController extends Controller
      */
     public function store(AddTripCollaboratorRequest $request, Trip $trip): JsonResponse
     {
-        // Only the owner can add collaborators
-        if (! $trip->isOwner(auth()->user())) {
+        // Only the owner or an admin can add collaborators
+        if (! $trip->isOwner(auth()->user()) && ! auth()->user()->isAdmin()) {
             return response()->json(['error' => 'Only the trip owner can add collaborators'], 403);
         }
 
@@ -82,8 +82,8 @@ class TripCollaboratorController extends Controller
      */
     public function destroy(Trip $trip, User $user): JsonResponse
     {
-        // Only the owner can remove collaborators
-        if (! $trip->isOwner(auth()->user())) {
+        // Only the owner or an admin can remove collaborators
+        if (! $trip->isOwner(auth()->user()) && ! auth()->user()->isAdmin()) {
             return response()->json(['error' => 'Only the trip owner can remove collaborators'], 403);
         }
 

--- a/app/Http/Controllers/TripController.php
+++ b/app/Http/Controllers/TripController.php
@@ -80,9 +80,18 @@ class TripController extends Controller
     {
         $this->authorize('update', $trip);
 
-        return Inertia::render('trips/create', [
-            'trip' => $trip,
-        ]);
+        $props = ['trip' => $trip];
+
+        // Pass owner info so the frontend can show an admin banner
+        if (auth()->user()->isAdmin() && $trip->user_id !== auth()->id()) {
+            $trip->load('user:id,name');
+            $props['owner'] = [
+                'id' => $trip->user->id,
+                'name' => $trip->user->name,
+            ];
+        }
+
+        return Inertia::render('trips/create', $props);
     }
 
     public function show(Trip $trip): JsonResponse

--- a/app/Services/TripService.php
+++ b/app/Services/TripService.php
@@ -26,6 +26,11 @@ class TripService
     public function getActiveTrip(User $user, ?int $tripId = null): Trip
     {
         if ($tripId) {
+            // Admins can access any trip directly
+            if ($user->isAdmin()) {
+                return Trip::findOrFail($tripId);
+            }
+
             // Check owned trips first
             $trip = $user->trips()->find($tripId);
             if ($trip) {
@@ -52,7 +57,7 @@ class TripService
     {
         $trip = Trip::findOrFail($tripId);
 
-        if (! $trip->hasAccess($user)) {
+        if (! $user->isAdmin() && ! $trip->hasAccess($user)) {
             throw new AuthorizationException('This action is unauthorized.');
         }
 

--- a/resources/js/pages/map.tsx
+++ b/resources/js/pages/map.tsx
@@ -9,17 +9,15 @@ import { Head, usePage } from '@inertiajs/react';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
-interface MapPageProps {
+type MapPageProps = SharedData & {
     trip?: {
         id: number;
     };
     owner?: TripOwner;
-    [key: string]: unknown;
-}
+};
 
 export default function MapPage() {
-    const { trip, owner } = usePage<MapPageProps>().props;
-    const { auth } = usePage<SharedData>().props;
+    const { trip, owner, auth } = usePage<MapPageProps>().props;
     const { t } = useTranslation();
 
     const breadcrumbs: BreadcrumbItem[] = [

--- a/resources/js/pages/map.tsx
+++ b/resources/js/pages/map.tsx
@@ -4,7 +4,7 @@ import { useModalState } from '@/hooks/use-modal-state';
 import { useTours } from '@/hooks/use-tours';
 import { useTrips } from '@/hooks/use-trips';
 import AppLayout from '@/layouts/app-layout';
-import { type BreadcrumbItem } from '@/types';
+import { type BreadcrumbItem, type SharedData, type TripOwner } from '@/types';
 import { Head, usePage } from '@inertiajs/react';
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -13,11 +13,13 @@ interface MapPageProps {
     trip?: {
         id: number;
     };
+    owner?: TripOwner;
     [key: string]: unknown;
 }
 
 export default function MapPage() {
-    const { trip } = usePage<MapPageProps>().props;
+    const { trip, owner } = usePage<MapPageProps>().props;
+    const { auth } = usePage<SharedData>().props;
     const { t } = useTranslation();
 
     const breadcrumbs: BreadcrumbItem[] = [
@@ -107,6 +109,11 @@ export default function MapPage() {
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Map" />
+            {auth.user?.role === 'admin' && owner && (
+                <div className="flex items-center gap-2 border-b border-red-200 bg-red-50 px-4 py-2 text-sm font-medium text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200">
+                    <span>Du bearbeitest die Reise von {owner.name}</span>
+                </div>
+            )}
             <MapContainer
                 selectedTripId={selectedTripId}
                 selectedTourId={selectedTourId}

--- a/resources/js/pages/trips/create.tsx
+++ b/resources/js/pages/trips/create.tsx
@@ -21,8 +21,13 @@ import {
     store as tripsStore,
     update as tripsUpdate,
 } from '@/routes/trips';
-import { type BreadcrumbItem, type Trip } from '@/types';
-import { Head, router } from '@inertiajs/react';
+import {
+    type BreadcrumbItem,
+    type SharedData,
+    type Trip,
+    type TripOwner,
+} from '@/types';
+import { Head, router, usePage } from '@inertiajs/react';
 import 'easymde/dist/easymde.min.css';
 import { ChevronLeft, ChevronRight, ImageIcon, Loader2 } from 'lucide-react';
 import { marked } from 'marked';
@@ -31,10 +36,14 @@ import SimpleMDE from 'react-simplemde-editor';
 
 interface CreateTripProps {
     trip?: Trip;
+    owner?: TripOwner;
 }
 
-export default function CreateTrip({ trip }: CreateTripProps) {
+export default function CreateTrip({ trip, owner }: CreateTripProps) {
     const isEditMode = !!trip;
+    const { auth } = usePage<SharedData>().props;
+    const isAdminViewingOtherTrip =
+        auth.user?.role === 'admin' && !!owner && owner.id !== auth.user.id;
 
     const breadcrumbs: BreadcrumbItem[] = [
         {
@@ -427,6 +436,11 @@ export default function CreateTrip({ trip }: CreateTripProps) {
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title={isEditMode ? 'Edit trip' : 'Create trip'} />
+            {isAdminViewingOtherTrip && owner && (
+                <div className="flex items-center gap-2 border-b border-red-200 bg-red-50 px-4 py-2 text-sm font-medium text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200">
+                    <span>Du bearbeitest die Reise von {owner.name}</span>
+                </div>
+            )}
             <div className="flex h-full flex-1 items-start justify-center p-4">
                 <div className="w-full max-w-2xl space-y-6 rounded-xl border border-sidebar-border/70 bg-card p-6 dark:border-sidebar-border">
                     <div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -53,16 +53,28 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     // Map route - show map for a specific trip
     Route::get('/map/{trip}', function (\App\Models\Trip $trip) {
-        // Authorize access to the trip (owner or shared user)
-        if (! $trip->hasAccess(auth()->user())) {
+        $user = auth()->user();
+
+        // Authorize access to the trip (owner, shared user, or admin)
+        if (! $trip->hasAccess($user) && ! $user->isAdmin()) {
             abort(403);
         }
 
-        return Inertia::render('map', [
+        $props = [
             'trip' => [
                 'id' => $trip->id,
             ],
-        ]);
+        ];
+
+        // Pass owner info so the frontend can show an admin banner
+        if ($user->isAdmin() && $trip->user_id !== $user->id) {
+            $props['owner'] = [
+                'id' => $trip->user->id,
+                'name' => $trip->user->name,
+            ];
+        }
+
+        return Inertia::render('map', $props);
     })->name('map.show');
 
     // Tour routes

--- a/routes/web.php
+++ b/routes/web.php
@@ -68,6 +68,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
         // Pass owner info so the frontend can show an admin banner
         if ($user->isAdmin() && $trip->user_id !== $user->id) {
+            $trip->loadMissing('user:id,name');
             $props['owner'] = [
                 'id' => $trip->user->id,
                 'name' => $trip->user->name,

--- a/tests/Feature/TripAdminManageTest.php
+++ b/tests/Feature/TripAdminManageTest.php
@@ -1,0 +1,156 @@
+<?php
+
+use App\Models\Trip;
+use App\Models\User;
+use App\Services\TripService;
+use Illuminate\Auth\Access\AuthorizationException;
+
+beforeEach(function () {
+    $this->admin = User::factory()->admin()->withoutTwoFactor()->create();
+    $this->owner = User::factory()->withoutTwoFactor()->create();
+    $this->tripService = new TripService;
+});
+
+// --- Map route ---
+
+test('admin can access map for another users trip', function () {
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
+
+    $response = $this->actingAs($this->admin)->get("/map/{$trip->id}");
+
+    $response->assertStatus(200);
+});
+
+test('map route passes owner prop when admin views another users trip', function () {
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
+
+    $response = $this->actingAs($this->admin)->get("/map/{$trip->id}");
+
+    $response->assertInertia(fn ($page) => $page
+        ->component('map')
+        ->has('owner')
+        ->where('owner.id', $this->owner->id)
+        ->where('owner.name', $this->owner->name)
+    );
+});
+
+test('map route does not pass owner prop when admin views own trip', function () {
+    $trip = Trip::factory()->create(['user_id' => $this->admin->id]);
+
+    $response = $this->actingAs($this->admin)->get("/map/{$trip->id}");
+
+    $response->assertInertia(fn ($page) => $page
+        ->component('map')
+        ->missing('owner')
+    );
+});
+
+test('regular user still cannot access map for another users trip', function () {
+    $otherUser = User::factory()->withoutTwoFactor()->create();
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
+
+    $response = $this->actingAs($otherUser)->get("/map/{$trip->id}");
+
+    $response->assertForbidden();
+});
+
+// --- TripController::edit ---
+
+test('admin can access edit page for another users trip', function () {
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
+
+    $response = $this->actingAs($this->admin)->get("/trips/{$trip->id}/edit");
+
+    $response->assertStatus(200);
+});
+
+test('edit page passes owner prop when admin edits another users trip', function () {
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
+
+    $response = $this->actingAs($this->admin)->get("/trips/{$trip->id}/edit");
+
+    $response->assertInertia(fn ($page) => $page
+        ->component('trips/create')
+        ->has('owner')
+        ->where('owner.id', $this->owner->id)
+        ->where('owner.name', $this->owner->name)
+    );
+});
+
+test('edit page does not pass owner prop when admin edits own trip', function () {
+    $trip = Trip::factory()->create(['user_id' => $this->admin->id]);
+
+    $response = $this->actingAs($this->admin)->get("/trips/{$trip->id}/edit");
+
+    $response->assertInertia(fn ($page) => $page
+        ->component('trips/create')
+        ->missing('owner')
+    );
+});
+
+// --- TripCollaboratorController ---
+
+test('admin can add collaborator to another users trip', function () {
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
+    $collaborator = User::factory()->withoutTwoFactor()->create();
+
+    $response = $this->actingAs($this->admin)->postJson("/trips/{$trip->id}/collaborators", [
+        'email' => $collaborator->email,
+    ]);
+
+    $response->assertStatus(201)
+        ->assertJsonFragment(['email' => $collaborator->email]);
+
+    $this->assertDatabaseHas('trip_user', [
+        'trip_id' => $trip->id,
+        'user_id' => $collaborator->id,
+    ]);
+});
+
+test('admin can remove collaborator from another users trip', function () {
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
+    $collaborator = User::factory()->withoutTwoFactor()->create();
+    $trip->sharedUsers()->attach($collaborator->id, ['collaboration_role' => 'editor']);
+
+    $response = $this->actingAs($this->admin)->deleteJson("/trips/{$trip->id}/collaborators/{$collaborator->id}");
+
+    $response->assertStatus(204);
+
+    $this->assertDatabaseMissing('trip_user', [
+        'trip_id' => $trip->id,
+        'user_id' => $collaborator->id,
+    ]);
+});
+
+// --- TripService::getActiveTrip ---
+
+test('getActiveTrip returns any trip for admin regardless of ownership', function () {
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
+
+    $result = $this->tripService->getActiveTrip($this->admin, $trip->id);
+
+    expect($result->id)->toBe($trip->id);
+});
+
+test('getActiveTrip falls back to default for admin when no tripId given', function () {
+    $result = $this->tripService->getActiveTrip($this->admin);
+
+    expect($result->name)->toBe('Default');
+});
+
+// --- TripService::findTripForUser ---
+
+test('findTripForUser returns any trip for admin regardless of ownership', function () {
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
+
+    $result = $this->tripService->findTripForUser($this->admin, $trip->id);
+
+    expect($result->id)->toBe($trip->id);
+});
+
+test('findTripForUser still throws AuthorizationException for non-admin accessing other users trip', function () {
+    $otherUser = User::factory()->withoutTwoFactor()->create();
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
+
+    $this->tripService->findTripForUser($otherUser, $trip->id);
+})->throws(AuthorizationException::class);


### PR DESCRIPTION
## Summary

- Admins can now open the map for any user's trip (previously got 403)
- Admins can add/remove collaborators on any trip, not just their own
- `TripService::getActiveTrip()` and `findTripForUser()` bypass ownership checks for admins so marker/route/tour API calls work correctly on foreign trips
- A clearly visible red banner ("Du bearbeitest die Reise von [Name]") appears on the map page and trip edit form whenever an admin is viewing another user's trip

## How to test

1. Log in as an admin
2. Go to the trips list with "Show all trips" enabled — click any trip from another user
3. Verify you can open the map, see the admin banner, add/remove markers, manage tours, manage collaborators, edit the trip form, delete, and export PDF
4. Verify the banner does **not** appear when viewing your own trips
5. Verify regular users still get 403 when trying to access another user's trip map

## Notes

- No breaking changes; all existing `TripPolicy` / `TourPolicy` / `MarkerPolicy` admin checks were already in place
- The pre-existing PDF export test failure (PHP GD extension not installed in this environment) is unrelated to these changes

Closes #438