### PR TITLE
refactor: extract inline map route closure to MapController (#443)

### DIFF
--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -15,15 +15,14 @@ class MapController extends Controller
     {
         $this->authorize('view', $trip);
 
-        $props = [
-            'trip' => [
-                'id' => $trip->id,
+        return Inertia::render('map', array_merge(
+            [
+                'trip' => [
+                    'id' => $trip->id,
+                ],
             ],
-        ];
-
-        $props = array_merge($props, $this->buildAdminOwnerProps($trip));
-
-        return Inertia::render('map', $props);
+            $this->buildAdminOwnerProps($trip),
+        ));
     }
 
     /**

--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Trip;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class MapController extends Controller
+{
+    use AuthorizesRequests;
+
+    public function show(Trip $trip): Response
+    {
+        $this->authorize('view', $trip);
+
+        $props = [
+            'trip' => [
+                'id' => $trip->id,
+            ],
+        ];
+
+        $props = array_merge($props, $this->buildAdminOwnerProps($trip));
+
+        return Inertia::render('map', $props);
+    }
+
+    /**
+     * Build owner props for the admin banner when an admin views another user's trip.
+     *
+     * @return array{owner?: array{id: int, name: string}}
+     */
+    private function buildAdminOwnerProps(Trip $trip): array
+    {
+        $user = auth()->user();
+
+        if (! $user->isAdmin() || $trip->user_id === $user->id) {
+            return [];
+        }
+
+        $trip->loadMissing('user:id,name');
+
+        return [
+            'owner' => [
+                'id' => $trip->user->id,
+                'name' => $trip->user->name,
+            ],
+        ];
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,13 +3,13 @@
 use App\Http\Controllers\Api\LeChatAgentController;
 use App\Http\Controllers\InvitationController;
 use App\Http\Controllers\MapboxController;
+use App\Http\Controllers\MapController;
 use App\Http\Controllers\MarkerController;
 use App\Http\Controllers\RouteController;
 use App\Http\Controllers\TourController;
 use App\Http\Controllers\TripCollaboratorController;
 use App\Http\Controllers\TripController;
 use Illuminate\Support\Facades\Route;
-use Inertia\Inertia;
 
 Route::get('/', function () {
     return redirect()->route('trips.index');
@@ -52,31 +52,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::delete('/trips/{trip}/collaborators/{user}', [TripCollaboratorController::class, 'destroy'])->name('trips.collaborators.destroy');
 
     // Map route - show map for a specific trip
-    Route::get('/map/{trip}', function (\App\Models\Trip $trip) {
-        $user = auth()->user();
-
-        // Authorize access to the trip (owner, shared user, or admin)
-        if (! $trip->hasAccess($user) && ! $user->isAdmin()) {
-            abort(403);
-        }
-
-        $props = [
-            'trip' => [
-                'id' => $trip->id,
-            ],
-        ];
-
-        // Pass owner info so the frontend can show an admin banner
-        if ($user->isAdmin() && $trip->user_id !== $user->id) {
-            $trip->loadMissing('user:id,name');
-            $props['owner'] = [
-                'id' => $trip->user->id,
-                'name' => $trip->user->name,
-            ];
-        }
-
-        return Inertia::render('map', $props);
-    })->name('map.show');
+    Route::get('/map/{trip}', [MapController::class, 'show'])->name('map.show');
 
     // Tour routes
     Route::get('/tours', [TourController::class, 'index'])->name('tours.index');

--- a/tests/Feature/MapControllerTest.php
+++ b/tests/Feature/MapControllerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use App\Models\Trip;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->user = User::factory()->withoutTwoFactor()->create();
+});
+
+test('owner can view the map for their trip', function () {
+    $trip = Trip::factory()->create(['user_id' => $this->user->id]);
+
+    $response = $this->actingAs($this->user)->get("/map/{$trip->id}");
+
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('map')
+            ->has('trip')
+            ->where('trip.id', $trip->id)
+            ->missing('owner')
+        );
+});
+
+test('shared user can view the map for a trip', function () {
+    $owner = User::factory()->withoutTwoFactor()->create();
+    $trip = Trip::factory()->create(['user_id' => $owner->id]);
+    $trip->sharedUsers()->attach($this->user);
+
+    $response = $this->actingAs($this->user)->get("/map/{$trip->id}");
+
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('map')
+            ->where('trip.id', $trip->id)
+            ->missing('owner')
+        );
+});
+
+test('unauthenticated user cannot view the map', function () {
+    $trip = Trip::factory()->create();
+
+    $response = $this->get("/map/{$trip->id}");
+
+    $response->assertRedirect('/login');
+});
+
+test('unauthorized user receives 403 when viewing map', function () {
+    $trip = Trip::factory()->create(); // belongs to a different user
+
+    $response = $this->actingAs($this->user)->get("/map/{$trip->id}");
+
+    $response->assertForbidden();
+});
+
+test('admin can view the map for any trip', function () {
+    $admin = User::factory()->withoutTwoFactor()->admin()->create();
+    $trip = Trip::factory()->create(); // belongs to a different user
+
+    $response = $this->actingAs($admin)->get("/map/{$trip->id}");
+
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('map')
+            ->where('trip.id', $trip->id)
+        );
+});
+
+test('admin viewing another user trip receives owner prop for banner', function () {
+    $admin = User::factory()->withoutTwoFactor()->admin()->create();
+    $owner = User::factory()->withoutTwoFactor()->create();
+    $trip = Trip::factory()->create(['user_id' => $owner->id]);
+
+    $response = $this->actingAs($admin)->get("/map/{$trip->id}");
+
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('map')
+            ->where('trip.id', $trip->id)
+            ->has('owner')
+            ->where('owner.id', $owner->id)
+            ->where('owner.name', $owner->name)
+        );
+});
+
+test('admin viewing their own trip does not receive owner prop', function () {
+    $admin = User::factory()->withoutTwoFactor()->admin()->create();
+    $trip = Trip::factory()->create(['user_id' => $admin->id]);
+
+    $response = $this->actingAs($admin)->get("/map/{$trip->id}");
+
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('map')
+            ->where('trip.id', $trip->id)
+            ->missing('owner')
+        );
+});


### PR DESCRIPTION
## Summary

- Extracts 20+ lines of business logic from the `Route::get('/map/{trip}')` closure in `routes/web.php` into a dedicated `MapController::show()` method
- Replaces manual `hasAccess()`/`isAdmin()` checks with `TripPolicy::view()` via `$this->authorize()`
- Encapsulates admin owner-banner logic in a `private buildAdminOwnerProps()` helper, preparing for consolidation with the identical pattern in `TripController` (see #448)
- Adds 7 feature tests covering all paths: owner, shared user, unauthorized user, unauthenticated user, admin viewing another's trip, admin viewing own trip

## How to test

```
php artisan test --compact tests/Feature/MapControllerTest.php
```

## Related

Closes #443
Part of the #260 Refactoring epic