### PR TITLE
Extract withLoading utility to reduce loading/error boilerplate

### DIFF
--- a/resources/js/hooks/use-tours.ts
+++ b/resources/js/hooks/use-tours.ts
@@ -17,47 +17,62 @@ export function useTours(selectedTripId: number | null) {
     const loadTours = useCallback(async () => {
         if (!selectedTripId) return;
 
-        await withLoading(setIsLoading, setError, async () => {
-            const response = await axios.get<Tour[]>(
-                toursIndex.url({ query: { trip_id: selectedTripId } }),
-            );
-            setTours(response.data);
-            setSelectedTourId(null); // Reset to "All markers" when switching trips
-        });
+        await withLoading(
+            setIsLoading,
+            setError,
+            async () => {
+                const response = await axios.get<Tour[]>(
+                    toursIndex.url({ query: { trip_id: selectedTripId } }),
+                );
+                setTours(response.data);
+                setSelectedTourId(null); // Reset to "All markers" when switching trips
+            },
+            { fallbackMessage: 'Failed to load tours', rethrow: false },
+        );
     }, [selectedTripId]);
 
     const createTour = useCallback(
         async (name: string) => {
             if (!selectedTripId) return;
 
-            return withLoading(setIsLoading, setError, async () => {
-                const response = await axios.post<Tour>(toursStore.url(), {
-                    name,
-                    trip_id: selectedTripId,
-                });
-                const newTour = response.data;
-                setTours((prev) => [...prev, newTour]);
-                setSelectedTourId(newTour.id);
+            return withLoading(
+                setIsLoading,
+                setError,
+                async () => {
+                    const response = await axios.post<Tour>(toursStore.url(), {
+                        name,
+                        trip_id: selectedTripId,
+                    });
+                    const newTour = response.data;
+                    setTours((prev) => [...prev, newTour]);
+                    setSelectedTourId(newTour.id);
 
-                return newTour;
-            });
+                    return newTour;
+                },
+                { fallbackMessage: 'Failed to create tour' },
+            );
         },
         [selectedTripId],
     );
 
     const deleteTour = useCallback(
         async (tour: Tour) => {
-            await withLoading(setIsLoading, setError, async () => {
-                await axios.delete(toursDestroy.url(tour.id));
+            await withLoading(
+                setIsLoading,
+                setError,
+                async () => {
+                    await axios.delete(toursDestroy.url(tour.id));
 
-                // Remove tour from tours array
-                setTours((prev) => prev.filter((t) => t.id !== tour.id));
+                    // Remove tour from tours array
+                    setTours((prev) => prev.filter((t) => t.id !== tour.id));
 
-                // Reset to "All markers" view if the deleted tour was selected
-                if (selectedTourId === tour.id) {
-                    setSelectedTourId(null);
-                }
-            });
+                    // Reset to "All markers" view if the deleted tour was selected
+                    if (selectedTourId === tour.id) {
+                        setSelectedTourId(null);
+                    }
+                },
+                { fallbackMessage: 'Failed to delete tour' },
+            );
         },
         [selectedTourId],
     );

--- a/resources/js/hooks/use-tours.ts
+++ b/resources/js/hooks/use-tours.ts
@@ -1,3 +1,4 @@
+import { withLoading } from '@/lib/with-loading';
 import {
     destroy as toursDestroy,
     index as toursIndex,
@@ -16,33 +17,20 @@ export function useTours(selectedTripId: number | null) {
     const loadTours = useCallback(async () => {
         if (!selectedTripId) return;
 
-        setIsLoading(true);
-        setError(null);
-
-        try {
+        await withLoading(setIsLoading, setError, async () => {
             const response = await axios.get<Tour[]>(
                 toursIndex.url({ query: { trip_id: selectedTripId } }),
             );
             setTours(response.data);
             setSelectedTourId(null); // Reset to "All markers" when switching trips
-        } catch (err) {
-            const error =
-                err instanceof Error ? err : new Error('Failed to load tours');
-            setError(error);
-            console.error('Failed to load tours:', error);
-        } finally {
-            setIsLoading(false);
-        }
+        });
     }, [selectedTripId]);
 
     const createTour = useCallback(
         async (name: string) => {
             if (!selectedTripId) return;
 
-            setIsLoading(true);
-            setError(null);
-
-            try {
+            return withLoading(setIsLoading, setError, async () => {
                 const response = await axios.post<Tour>(toursStore.url(), {
                     name,
                     trip_id: selectedTripId,
@@ -52,27 +40,14 @@ export function useTours(selectedTripId: number | null) {
                 setSelectedTourId(newTour.id);
 
                 return newTour;
-            } catch (err) {
-                const error =
-                    err instanceof Error
-                        ? err
-                        : new Error('Failed to create tour');
-                setError(error);
-                console.error('Failed to create tour:', error);
-                throw error;
-            } finally {
-                setIsLoading(false);
-            }
+            });
         },
         [selectedTripId],
     );
 
     const deleteTour = useCallback(
         async (tour: Tour) => {
-            setIsLoading(true);
-            setError(null);
-
-            try {
+            await withLoading(setIsLoading, setError, async () => {
                 await axios.delete(toursDestroy.url(tour.id));
 
                 // Remove tour from tours array
@@ -82,17 +57,7 @@ export function useTours(selectedTripId: number | null) {
                 if (selectedTourId === tour.id) {
                     setSelectedTourId(null);
                 }
-            } catch (err) {
-                const error =
-                    err instanceof Error
-                        ? err
-                        : new Error('Failed to delete tour');
-                setError(error);
-                console.error('Failed to delete tour:', error);
-                throw error;
-            } finally {
-                setIsLoading(false);
-            }
+            });
         },
         [selectedTourId],
     );

--- a/resources/js/hooks/use-trips.ts
+++ b/resources/js/hooks/use-trips.ts
@@ -16,63 +16,90 @@ export function useTrips(showAll: boolean = false) {
     const [error, setError] = useState<Error | null>(null);
 
     const loadTrips = useCallback(async () => {
-        await withLoading(setIsLoading, setError, async () => {
-            const url = showAll
-                ? `${tripsIndex.url()}?show_all=1`
-                : tripsIndex.url();
-            const response = await axios.get<Trip[]>(url);
-            const loadedTrips = response.data;
-            setTrips(loadedTrips);
+        await withLoading(
+            setIsLoading,
+            setError,
+            async () => {
+                const url = showAll
+                    ? `${tripsIndex.url()}?show_all=1`
+                    : tripsIndex.url();
+                const response = await axios.get<Trip[]>(url);
+                const loadedTrips = response.data;
+                setTrips(loadedTrips);
 
-            // Don't auto-select the first trip - let the user choose
-        });
+                // Don't auto-select the first trip - let the user choose
+            },
+            { fallbackMessage: 'Failed to load trips', rethrow: false },
+        );
     }, [showAll]);
 
     const createTrip = useCallback(
         async (name: string, country: string | null = null) => {
-            return withLoading(setIsLoading, setError, async () => {
-                const response = await axios.post<Trip>(tripsStore.url(), {
-                    name,
-                    country,
-                });
-                const newTrip = response.data;
-                setTrips((prev) => [...prev, newTrip]);
-                setSelectedTripId(newTrip.id);
+            return withLoading(
+                setIsLoading,
+                setError,
+                async () => {
+                    const response = await axios.post<Trip>(tripsStore.url(), {
+                        name,
+                        country,
+                    });
+                    const newTrip = response.data;
+                    setTrips((prev) => [...prev, newTrip]);
+                    setSelectedTripId(newTrip.id);
 
-                return newTrip;
-            });
+                    return newTrip;
+                },
+                { fallbackMessage: 'Failed to create trip' },
+            );
         },
         [],
     );
 
     const renameTrip = useCallback(async (trip: Trip, name: string) => {
-        return withLoading(setIsLoading, setError, async () => {
-            const response = await axios.put<Trip>(tripsUpdate.url(trip.id), {
-                name,
-            });
-            const updatedTrip = response.data;
-            setTrips((prev) =>
-                prev.map((t) => (t.id === updatedTrip.id ? updatedTrip : t)),
-            );
+        return withLoading(
+            setIsLoading,
+            setError,
+            async () => {
+                const response = await axios.put<Trip>(
+                    tripsUpdate.url(trip.id),
+                    { name },
+                );
+                const updatedTrip = response.data;
+                setTrips((prev) =>
+                    prev.map((t) =>
+                        t.id === updatedTrip.id ? updatedTrip : t,
+                    ),
+                );
 
-            return updatedTrip;
-        });
+                return updatedTrip;
+            },
+            { fallbackMessage: 'Failed to rename trip' },
+        );
     }, []);
 
     const deleteTrip = useCallback(
         async (tripId: number) => {
-            await withLoading(setIsLoading, setError, async () => {
-                await axios.delete(tripsDestroy.url(tripId));
-                setTrips((prev) => prev.filter((t) => t.id !== tripId));
+            await withLoading(
+                setIsLoading,
+                setError,
+                async () => {
+                    await axios.delete(tripsDestroy.url(tripId));
+                    setTrips((prev) => prev.filter((t) => t.id !== tripId));
 
-                // If we deleted the selected trip, select the first remaining trip
-                if (selectedTripId === tripId) {
-                    const remainingTrips = trips.filter((t) => t.id !== tripId);
-                    setSelectedTripId(
-                        remainingTrips.length > 0 ? remainingTrips[0].id : null,
-                    );
-                }
-            });
+                    // If we deleted the selected trip, select the first remaining trip
+                    if (selectedTripId === tripId) {
+                        const remainingTrips = trips.filter(
+                            (t) => t.id !== tripId,
+                        );
+                        setSelectedTripId(
+                            remainingTrips.length > 0
+                                ? remainingTrips[0].id
+                                : null,
+                        );
+                    }
+                },
+                { fallbackMessage: 'Failed to delete trip' },
+            );
         },
         [selectedTripId, trips],
     );
@@ -86,24 +113,29 @@ export function useTrips(showAll: boolean = false) {
                 zoom: number;
             },
         ) => {
-            return withLoading(setIsLoading, setError, async () => {
-                const response = await axios.put<Trip>(
-                    tripsUpdate.url(tripId),
-                    {
-                        viewport_latitude: viewport.latitude,
-                        viewport_longitude: viewport.longitude,
-                        viewport_zoom: viewport.zoom,
-                    },
-                );
-                const updatedTrip = response.data;
-                setTrips((prev) =>
-                    prev.map((t) =>
-                        t.id === updatedTrip.id ? updatedTrip : t,
-                    ),
-                );
+            return withLoading(
+                setIsLoading,
+                setError,
+                async () => {
+                    const response = await axios.put<Trip>(
+                        tripsUpdate.url(tripId),
+                        {
+                            viewport_latitude: viewport.latitude,
+                            viewport_longitude: viewport.longitude,
+                            viewport_zoom: viewport.zoom,
+                        },
+                    );
+                    const updatedTrip = response.data;
+                    setTrips((prev) =>
+                        prev.map((t) =>
+                            t.id === updatedTrip.id ? updatedTrip : t,
+                        ),
+                    );
 
-                return updatedTrip;
-            });
+                    return updatedTrip;
+                },
+                { fallbackMessage: 'Failed to update trip viewport' },
+            );
         },
         [],
     );

--- a/resources/js/hooks/use-trips.ts
+++ b/resources/js/hooks/use-trips.ts
@@ -1,3 +1,4 @@
+import { withLoading } from '@/lib/with-loading';
 import {
     destroy as tripsDestroy,
     index as tripsIndex,
@@ -15,10 +16,7 @@ export function useTrips(showAll: boolean = false) {
     const [error, setError] = useState<Error | null>(null);
 
     const loadTrips = useCallback(async () => {
-        setIsLoading(true);
-        setError(null);
-
-        try {
+        await withLoading(setIsLoading, setError, async () => {
             const url = showAll
                 ? `${tripsIndex.url()}?show_all=1`
                 : tripsIndex.url();
@@ -27,22 +25,12 @@ export function useTrips(showAll: boolean = false) {
             setTrips(loadedTrips);
 
             // Don't auto-select the first trip - let the user choose
-        } catch (err) {
-            const error =
-                err instanceof Error ? err : new Error('Failed to load trips');
-            setError(error);
-            console.error('Failed to load trips:', error);
-        } finally {
-            setIsLoading(false);
-        }
+        });
     }, [showAll]);
 
     const createTrip = useCallback(
         async (name: string, country: string | null = null) => {
-            setIsLoading(true);
-            setError(null);
-
-            try {
+            return withLoading(setIsLoading, setError, async () => {
                 const response = await axios.post<Trip>(tripsStore.url(), {
                     name,
                     country,
@@ -52,26 +40,13 @@ export function useTrips(showAll: boolean = false) {
                 setSelectedTripId(newTrip.id);
 
                 return newTrip;
-            } catch (err) {
-                const error =
-                    err instanceof Error
-                        ? err
-                        : new Error('Failed to create trip');
-                setError(error);
-                console.error('Failed to create trip:', error);
-                throw error;
-            } finally {
-                setIsLoading(false);
-            }
+            });
         },
         [],
     );
 
     const renameTrip = useCallback(async (trip: Trip, name: string) => {
-        setIsLoading(true);
-        setError(null);
-
-        try {
+        return withLoading(setIsLoading, setError, async () => {
             const response = await axios.put<Trip>(tripsUpdate.url(trip.id), {
                 name,
             });
@@ -81,23 +56,12 @@ export function useTrips(showAll: boolean = false) {
             );
 
             return updatedTrip;
-        } catch (err) {
-            const error =
-                err instanceof Error ? err : new Error('Failed to rename trip');
-            setError(error);
-            console.error('Failed to rename trip:', error);
-            throw error;
-        } finally {
-            setIsLoading(false);
-        }
+        });
     }, []);
 
     const deleteTrip = useCallback(
         async (tripId: number) => {
-            setIsLoading(true);
-            setError(null);
-
-            try {
+            await withLoading(setIsLoading, setError, async () => {
                 await axios.delete(tripsDestroy.url(tripId));
                 setTrips((prev) => prev.filter((t) => t.id !== tripId));
 
@@ -108,17 +72,7 @@ export function useTrips(showAll: boolean = false) {
                         remainingTrips.length > 0 ? remainingTrips[0].id : null,
                     );
                 }
-            } catch (err) {
-                const error =
-                    err instanceof Error
-                        ? err
-                        : new Error('Failed to delete trip');
-                setError(error);
-                console.error('Failed to delete trip:', error);
-                throw error;
-            } finally {
-                setIsLoading(false);
-            }
+            });
         },
         [selectedTripId, trips],
     );
@@ -132,10 +86,7 @@ export function useTrips(showAll: boolean = false) {
                 zoom: number;
             },
         ) => {
-            setIsLoading(true);
-            setError(null);
-
-            try {
+            return withLoading(setIsLoading, setError, async () => {
                 const response = await axios.put<Trip>(
                     tripsUpdate.url(tripId),
                     {
@@ -152,17 +103,7 @@ export function useTrips(showAll: boolean = false) {
                 );
 
                 return updatedTrip;
-            } catch (err) {
-                const error =
-                    err instanceof Error
-                        ? err
-                        : new Error('Failed to update trip viewport');
-                setError(error);
-                console.error('Failed to update trip viewport:', error);
-                throw error;
-            } finally {
-                setIsLoading(false);
-            }
+            });
         },
         [],
     );

--- a/resources/js/lib/with-loading.ts
+++ b/resources/js/lib/with-loading.ts
@@ -1,0 +1,25 @@
+type SetState<T> = (value: T | ((prev: T) => T)) => void;
+
+/**
+ * Wraps an async operation with loading and error state management.
+ * Sets isLoading to true before the operation and false after (regardless of outcome).
+ * On error, normalises the thrown value to an Error and stores it via setError.
+ */
+export async function withLoading<T>(
+    setIsLoading: SetState<boolean>,
+    setError: SetState<Error | null>,
+    fn: () => Promise<T>,
+): Promise<T> {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+        return await fn();
+    } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        setError(error);
+        throw error;
+    } finally {
+        setIsLoading(false);
+    }
+}

--- a/resources/js/lib/with-loading.ts
+++ b/resources/js/lib/with-loading.ts
@@ -1,5 +1,21 @@
 type SetState<T> = (value: T | ((prev: T) => T)) => void;
 
+interface WithLoadingOptions {
+    /**
+     * Fallback message used when a non-Error value is thrown.
+     * Defaults to the thrown value coerced to a string via String().
+     */
+    fallbackMessage?: string;
+
+    /**
+     * Whether to rethrow the error after storing it via setError.
+     * Set to false for "fire-and-forget" load operations called from useEffect,
+     * where an unhandled promise rejection would otherwise be surfaced.
+     * Defaults to true.
+     */
+    rethrow?: boolean;
+}
+
 /**
  * Wraps an async operation with loading and error state management.
  * Sets isLoading to true before the operation and false after (regardless of outcome).
@@ -9,16 +25,24 @@ export async function withLoading<T>(
     setIsLoading: SetState<boolean>,
     setError: SetState<Error | null>,
     fn: () => Promise<T>,
-): Promise<T> {
+    { fallbackMessage, rethrow = true }: WithLoadingOptions = {},
+): Promise<T | undefined> {
     setIsLoading(true);
     setError(null);
 
     try {
         return await fn();
     } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err));
+        const message =
+            err instanceof Error
+                ? err.message
+                : (fallbackMessage ?? String(err));
+        const error = err instanceof Error ? err : new Error(message);
         setError(error);
-        throw error;
+
+        if (rethrow) {
+            throw error;
+        }
     } finally {
         setIsLoading(false);
     }


### PR DESCRIPTION
## Summary

- Introduces `resources/js/lib/with-loading.ts`: a small `withLoading<T>(setIsLoading, setError, fn, options)` utility that centralises the repeated `setIsLoading / setError(null) / try-catch-finally` pattern
- Refactors `use-trips.ts` (5 operations) and `use-tours.ts` (3 operations) to use the new utility, removing ~70 lines of boilerplate
- `use-markers.ts` and `use-routes.ts` are intentionally unchanged — they use `toast.error()` / no `isLoading` state, so the pattern does not apply

## How to test

1. Load the map page — trips and tours should load normally
2. Create, rename, delete a trip — all operations should behave identically to before
3. Create and delete a tour — same as above
4. Introduce a network error (devtools → offline) and verify the error state is still set correctly

## Notes

- `withLoading` now accepts an options object `{ fallbackMessage?, rethrow? }`:
  - `fallbackMessage`: used when a non-Error value is thrown, restoring the operation-specific messages that were present in the original code
  - `rethrow` (default `true`): set to `false` for fire-and-forget load operations called from `useEffect` to avoid unhandled promise rejections
- Load operations (`loadTrips`, `loadTours`) use `rethrow: false`; mutation operations rethrow so callers can handle errors
- `use-markers.ts` and `use-routes.ts` were intentionally excluded from this PR as they follow a different error pattern. Issue #445 will be partially addressed; a follow-up can be tracked separately if full coverage is desired.