### PR TITLE
Fix use-trip-notes.ts: replace fetch with axios and fix state mutation

### DIFF
--- a/resources/js/components/map-container.tsx
+++ b/resources/js/components/map-container.tsx
@@ -1,6 +1,7 @@
 import TravelMap from '@/components/travel-map';
 import { Tour } from '@/types/tour';
 import { Trip } from '@/types/trip';
+import { Dispatch, SetStateAction } from 'react';
 
 interface MapContainerProps {
     selectedTripId: number | null;
@@ -8,6 +9,7 @@ interface MapContainerProps {
     tours: Tour[];
     trips: Trip[];
     onToursUpdate: (tours: Tour[]) => void;
+    onTripsUpdate: Dispatch<SetStateAction<Trip[]>>;
     onReloadTours: () => void;
     onSelectTour: (tourId: number | null) => void;
     onCreateTour: () => void;
@@ -24,6 +26,7 @@ export function MapContainer({
     tours,
     trips,
     onToursUpdate,
+    onTripsUpdate,
     onReloadTours,
     onSelectTour,
     onCreateTour,
@@ -38,6 +41,7 @@ export function MapContainer({
                 tours={tours}
                 trips={trips}
                 onToursUpdate={onToursUpdate}
+                onTripsUpdate={onTripsUpdate}
                 onReloadTours={onReloadTours}
                 onSelectTour={onSelectTour}
                 onCreateTour={onCreateTour}

--- a/resources/js/components/travel-map/index.tsx
+++ b/resources/js/components/travel-map/index.tsx
@@ -22,10 +22,17 @@ import { useTourLines } from '@/hooks/use-tour-lines';
 import { useTourMarkers } from '@/hooks/use-tour-markers';
 import { useTripNotes } from '@/hooks/use-trip-notes';
 import { getBoundingBoxFromTrip } from '@/lib/map-utils';
+import { Route } from '@/types/route';
 import { Tour } from '@/types/tour';
 import { Trip } from '@/types/trip';
 import 'mapbox-gl/dist/mapbox-gl.css';
-import { useCallback, useEffect, useRef } from 'react';
+import {
+    Dispatch,
+    SetStateAction,
+    useCallback,
+    useEffect,
+    useRef,
+} from 'react';
 
 interface TravelMapProps {
     selectedTripId: number | null;
@@ -33,6 +40,7 @@ interface TravelMapProps {
     tours: Tour[];
     trips: Trip[];
     onToursUpdate: (tours: Tour[]) => void;
+    onTripsUpdate: Dispatch<SetStateAction<Trip[]>>;
     onReloadTours: () => void;
     onSelectTour: (tourId: number | null) => void;
     onCreateTour: () => void;
@@ -63,6 +71,7 @@ export default function TravelMap({
     tours,
     trips,
     onToursUpdate,
+    onTripsUpdate,
     onSelectTour,
     onCreateTour,
     onDeleteTour,
@@ -129,7 +138,7 @@ export default function TravelMap({
     const { isTripNotesModalOpen, closeTripNotesModal, handleSaveTripNotes } =
         useTripNotes({
             selectedTripId,
-            trips,
+            setTrips: onTripsUpdate,
         });
 
     // Marker management

--- a/resources/js/hooks/use-trip-notes.ts
+++ b/resources/js/hooks/use-trip-notes.ts
@@ -1,10 +1,11 @@
 import { update as tripsUpdate } from '@/routes/trips';
 import { Trip } from '@/types/trip';
-import { useCallback, useState } from 'react';
+import axios from 'axios';
+import { Dispatch, SetStateAction, useCallback, useState } from 'react';
 
 interface UseTripNotesProps {
     selectedTripId: number | null;
-    trips: Trip[];
+    setTrips: Dispatch<SetStateAction<Trip[]>>;
 }
 
 interface UseTripNotesReturn {
@@ -19,7 +20,7 @@ interface UseTripNotesReturn {
  */
 export function useTripNotes({
     selectedTripId,
-    trips,
+    setTrips,
 }: UseTripNotesProps): UseTripNotesReturn {
     // Trip notes modal state
     const [isTripNotesModalOpen, setIsTripNotesModalOpen] = useState(false);
@@ -40,33 +41,23 @@ export function useTripNotes({
             if (!selectedTripId) return;
 
             try {
-                const response = await fetch(tripsUpdate.url(selectedTripId), {
-                    method: 'PUT',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRF-TOKEN':
-                            document
-                                .querySelector('meta[name="csrf-token"]')
-                                ?.getAttribute('content') || '',
-                    },
-                    body: JSON.stringify({ notes }),
-                });
+                const response = await axios.put<Trip>(
+                    tripsUpdate.url(selectedTripId),
+                    { notes },
+                );
 
-                if (!response.ok) {
-                    throw new Error('Failed to update trip notes');
-                }
-
-                // Update the local trips state with the new notes
-                const trip = trips.find((t) => t.id === selectedTripId);
-                if (trip) {
-                    trip.notes = notes;
-                }
+                const updatedTrip = response.data;
+                setTrips((prev) =>
+                    prev.map((t) =>
+                        t.id === updatedTrip.id ? updatedTrip : t,
+                    ),
+                );
             } catch (error) {
                 console.error('Failed to save trip notes:', error);
                 throw error;
             }
         },
-        [selectedTripId, trips],
+        [selectedTripId, setTrips],
     );
 
     return {

--- a/resources/js/pages/map.tsx
+++ b/resources/js/pages/map.tsx
@@ -29,6 +29,7 @@ export default function MapPage() {
 
     const {
         trips,
+        setTrips,
         selectedTripId,
         setSelectedTripId,
         createTrip,
@@ -118,6 +119,7 @@ export default function MapPage() {
                 tours={tours}
                 trips={trips}
                 onToursUpdate={setTours}
+                onTripsUpdate={setTrips}
                 onReloadTours={loadTours}
                 onSelectTour={setSelectedTourId}
                 onCreateTour={openCreateTourModal}


### PR DESCRIPTION
## Summary

- **#446**: Replaces `fetch()` + manual `document.querySelector('meta[name="csrf-token"]')` with `axios.put()`, which handles CSRF automatically via the existing axios interceptor — consistent with all other hooks
- **#447**: Removes `trip.notes = notes` direct mutation (which silently skips re-renders) and replaces it with an immutable `setTrips()` update using the server response; threads `setTrips` down through `MapContainer` → `TravelMap` → `useTripNotes` as `onTripsUpdate`

## How to test

1. Open a trip, open the trip notes modal, type some notes and save
2. Verify the notes are persisted (reload page) and the UI updates immediately without a refresh
3. Simulate a network error (devtools → offline) — verify the error is thrown and visible

Closes #446
Closes #447