### PR TITLE
Deduplicate admin owner-banner logic into base Controller

### DIFF
--- a/app/Http/Controllers/Concerns/BuildsAdminOwnerProps.php
+++ b/app/Http/Controllers/Concerns/BuildsAdminOwnerProps.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Concerns;
+
+use App\Models\Trip;
+
+trait BuildsAdminOwnerProps
+{
+    /**
+     * Build owner props for the admin banner when an admin views another user's trip.
+     *
+     * @return array{owner?: array{id: int, name: string}}
+     */
+    protected function buildAdminOwnerProps(Trip $trip): array
+    {
+        $user = auth()->user();
+
+        if (! $user->isAdmin() || $trip->user_id === $user->id) {
+            return [];
+        }
+
+        $trip->loadMissing('user:id,name');
+
+        return [
+            'owner' => [
+                'id' => $trip->user->id,
+                'name' => $trip->user->name,
+            ],
+        ];
+    }
+}

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,30 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Trip;
+
 abstract class Controller
 {
-    //
+    /**
+     * Build owner props for the admin banner when an admin views another user's trip.
+     *
+     * @return array{owner?: array{id: int, name: string}}
+     */
+    protected function buildAdminOwnerProps(Trip $trip): array
+    {
+        $user = auth()->user();
+
+        if (! $user->isAdmin() || $trip->user_id === $user->id) {
+            return [];
+        }
+
+        $trip->loadMissing('user:id,name');
+
+        return [
+            'owner' => [
+                'id' => $trip->user->id,
+                'name' => $trip->user->name,
+            ],
+        ];
+    }
 }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,30 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Trip;
-
 abstract class Controller
 {
-    /**
-     * Build owner props for the admin banner when an admin views another user's trip.
-     *
-     * @return array{owner?: array{id: int, name: string}}
-     */
-    protected function buildAdminOwnerProps(Trip $trip): array
-    {
-        $user = auth()->user();
-
-        if (! $user->isAdmin() || $trip->user_id === $user->id) {
-            return [];
-        }
-
-        $trip->loadMissing('user:id,name');
-
-        return [
-            'owner' => [
-                'id' => $trip->user->id,
-                'name' => $trip->user->name,
-            ],
-        ];
-    }
+    //
 }

--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -24,27 +24,4 @@ class MapController extends Controller
             $this->buildAdminOwnerProps($trip),
         ));
     }
-
-    /**
-     * Build owner props for the admin banner when an admin views another user's trip.
-     *
-     * @return array{owner?: array{id: int, name: string}}
-     */
-    private function buildAdminOwnerProps(Trip $trip): array
-    {
-        $user = auth()->user();
-
-        if (! $user->isAdmin() || $trip->user_id === $user->id) {
-            return [];
-        }
-
-        $trip->loadMissing('user:id,name');
-
-        return [
-            'owner' => [
-                'id' => $trip->user->id,
-                'name' => $trip->user->name,
-            ],
-        ];
-    }
 }

--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Controllers\Concerns\BuildsAdminOwnerProps;
 use App\Models\Trip;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Inertia\Inertia;
@@ -10,6 +11,7 @@ use Inertia\Response;
 class MapController extends Controller
 {
     use AuthorizesRequests;
+    use BuildsAdminOwnerProps;
 
     public function show(Trip $trip): Response
     {

--- a/app/Http/Controllers/TripController.php
+++ b/app/Http/Controllers/TripController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Enums\PdfTemplate;
+use App\Http\Controllers\Concerns\BuildsAdminOwnerProps;
 use App\Http\Requests\FetchTripImageRequest;
 use App\Http\Requests\StoreTripRequest;
 use App\Http\Requests\UpdateTripRequest;
@@ -19,6 +20,7 @@ use Inertia\Response;
 class TripController extends Controller
 {
     use AuthorizesRequests;
+    use BuildsAdminOwnerProps;
 
     public function __construct(
         private readonly UnsplashService $unsplashService,

--- a/app/Http/Controllers/TripController.php
+++ b/app/Http/Controllers/TripController.php
@@ -80,18 +80,10 @@ class TripController extends Controller
     {
         $this->authorize('update', $trip);
 
-        $props = ['trip' => $trip];
-
-        // Pass owner info so the frontend can show an admin banner
-        if (auth()->user()->isAdmin() && $trip->user_id !== auth()->id()) {
-            $trip->load('user:id,name');
-            $props['owner'] = [
-                'id' => $trip->user->id,
-                'name' => $trip->user->name,
-            ];
-        }
-
-        return Inertia::render('trips/create', $props);
+        return Inertia::render('trips/create', array_merge(
+            ['trip' => $trip],
+            $this->buildAdminOwnerProps($trip),
+        ));
     }
 
     public function show(Trip $trip): JsonResponse


### PR DESCRIPTION
## Summary

- Moves `buildAdminOwnerProps()` from `MapController` (private) to the base `Controller` (protected) so it can be shared
- Replaces the inline duplication in `TripController::edit()` with the shared method
- Fixes the inconsistency: `TripController` was using `load()` while `MapController` used `loadMissing()` — the shared method now always uses `loadMissing()` to avoid redundant queries

## How to test

1. As an admin, open another user's trip in the map view — the admin banner should still appear
2. As an admin, open another user's trip via the edit page (`/trips/{id}/edit`) — the admin banner should still appear
3. As a regular user, verify no banner appears

Closes #448