### PR TITLE
Refactor TourController: constructor injection and Form Requests (#449, #450)

### DIFF
--- a/app/Http/Controllers/TourController.php
+++ b/app/Http/Controllers/TourController.php
@@ -4,7 +4,9 @@ namespace App\Http\Controllers;
 
 use App\Exceptions\MapboxQuotaExceededException;
 use App\Exceptions\RoutingProviderException;
+use App\Http\Requests\ReorderTourMarkersRequest;
 use App\Http\Requests\StoreTourRequest;
+use App\Http\Requests\TourMarkerRequest;
 use App\Http\Requests\UpdateTourRequest;
 use App\Http\Resources\TourResource;
 use App\Models\Marker;
@@ -21,6 +23,11 @@ use Illuminate\Support\Facades\Log;
 class TourController extends Controller
 {
     use AuthorizesRequests;
+
+    public function __construct(
+        private readonly MapboxMatrixService $matrixService,
+        private readonly TourSortingService $sortingService,
+    ) {}
 
     public function index(Request $request): JsonResponse
     {
@@ -83,13 +90,11 @@ class TourController extends Controller
         return response()->json(null, 204);
     }
 
-    public function attachMarker(Request $request, Tour $tour): JsonResponse
+    public function attachMarker(TourMarkerRequest $request, Tour $tour): JsonResponse
     {
         $this->authorize('update', $tour);
 
-        $validated = $request->validate([
-            'marker_id' => 'required|uuid|exists:markers,id',
-        ]);
+        $validated = $request->validated();
 
         $marker = Marker::findOrFail($validated['marker_id']);
 
@@ -105,13 +110,11 @@ class TourController extends Controller
         return response()->json(new TourResource($tour->load(['markers', 'routes'])));
     }
 
-    public function detachMarker(Request $request, Tour $tour): JsonResponse
+    public function detachMarker(TourMarkerRequest $request, Tour $tour): JsonResponse
     {
         $this->authorize('update', $tour);
 
-        $validated = $request->validate([
-            'marker_id' => 'required|uuid|exists:markers,id',
-        ]);
+        $validated = $request->validated();
 
         // When duplicates are allowed, only remove one instance of the marker
         // Get the first pivot record for this marker-tour combination
@@ -130,15 +133,11 @@ class TourController extends Controller
         return response()->json(new TourResource($tour->load(['markers', 'routes'])));
     }
 
-    public function reorderMarkers(Request $request, Tour $tour): JsonResponse
+    public function reorderMarkers(ReorderTourMarkersRequest $request, Tour $tour): JsonResponse
     {
         $this->authorize('update', $tour);
 
-        $validated = $request->validate([
-            'marker_ids' => 'required|array',
-            'marker_ids.*' => 'required|uuid|exists:markers,id',
-        ]);
-
+        $validated = $request->validated();
         $markerIds = $validated['marker_ids'];
 
         // Detach all current markers
@@ -173,13 +172,8 @@ class TourController extends Controller
         }
 
         try {
-            // Calculate distance matrix using Mapbox Matrix API
-            $matrixService = app(MapboxMatrixService::class);
-            $matrix = $matrixService->calculateMatrix($markers);
-
-            // Sort markers optimally using the distance matrix
-            $sortingService = app(TourSortingService::class);
-            $sortedMarkerIds = $sortingService->sortMarkersOptimally($markers, $matrix);
+            $matrix = $this->matrixService->calculateMatrix($markers);
+            $sortedMarkerIds = $this->sortingService->sortMarkersOptimally($markers, $matrix);
 
             // Update marker positions in database
             $tour->markers()->detach();

--- a/app/Http/Requests/ReorderTourMarkersRequest.php
+++ b/app/Http/Requests/ReorderTourMarkersRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReorderTourMarkersRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'marker_ids' => ['required', 'array'],
+            'marker_ids.*' => ['required', 'uuid', 'exists:markers,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/ReorderTourMarkersRequest.php
+++ b/app/Http/Requests/ReorderTourMarkersRequest.php
@@ -11,7 +11,7 @@ class ReorderTourMarkersRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return true;
+        return $this->user()?->can('update', $this->route('tour')) ?? false;
     }
 
     /**

--- a/app/Http/Requests/TourMarkerRequest.php
+++ b/app/Http/Requests/TourMarkerRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TourMarkerRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'marker_id' => ['required', 'uuid', 'exists:markers,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/TourMarkerRequest.php
+++ b/app/Http/Requests/TourMarkerRequest.php
@@ -11,7 +11,7 @@ class TourMarkerRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return true;
+        return $this->user()?->can('update', $this->route('tour')) ?? false;
     }
 
     /**

--- a/tests/Feature/TourControllerTest.php
+++ b/tests/Feature/TourControllerTest.php
@@ -439,3 +439,74 @@ test('tour with duplicate markers maintains correct positions', function () {
     expect($markers[1]['position'])->toBe(1);
     expect($markers[2]['position'])->toBe(2);
 });
+
+test('attachMarker rejects missing marker_id', function () {
+    $tour = Tour::factory()->create(['trip_id' => $this->trip->id]);
+
+    $response = $this->actingAs($this->user)->postJson("/tours/{$tour->id}/markers", []);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['marker_id']);
+});
+
+test('attachMarker rejects non-uuid marker_id', function () {
+    $tour = Tour::factory()->create(['trip_id' => $this->trip->id]);
+
+    $response = $this->actingAs($this->user)->postJson("/tours/{$tour->id}/markers", [
+        'marker_id' => 'not-a-uuid',
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['marker_id']);
+});
+
+test('attachMarker rejects non-existent marker_id', function () {
+    $tour = Tour::factory()->create(['trip_id' => $this->trip->id]);
+
+    $response = $this->actingAs($this->user)->postJson("/tours/{$tour->id}/markers", [
+        'marker_id' => '00000000-0000-0000-0000-000000000000',
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['marker_id']);
+});
+
+test('detachMarker rejects missing marker_id', function () {
+    $tour = Tour::factory()->create(['trip_id' => $this->trip->id]);
+
+    $response = $this->actingAs($this->user)->deleteJson("/tours/{$tour->id}/markers", []);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['marker_id']);
+});
+
+test('reorderMarkers rejects missing marker_ids', function () {
+    $tour = Tour::factory()->create(['trip_id' => $this->trip->id]);
+
+    $response = $this->actingAs($this->user)->putJson("/tours/{$tour->id}/markers/reorder", []);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['marker_ids']);
+});
+
+test('reorderMarkers rejects non-array marker_ids', function () {
+    $tour = Tour::factory()->create(['trip_id' => $this->trip->id]);
+
+    $response = $this->actingAs($this->user)->putJson("/tours/{$tour->id}/markers/reorder", [
+        'marker_ids' => 'not-an-array',
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['marker_ids']);
+});
+
+test('reorderMarkers rejects non-existent marker in marker_ids', function () {
+    $tour = Tour::factory()->create(['trip_id' => $this->trip->id]);
+
+    $response = $this->actingAs($this->user)->putJson("/tours/{$tour->id}/markers/reorder", [
+        'marker_ids' => ['00000000-0000-0000-0000-000000000000'],
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['marker_ids.0']);
+});


### PR DESCRIPTION
## Summary

- Replace `app()` service-locator calls in `TourController` with proper constructor injection of `MapboxMatrixService` and `TourSortingService` (#449)
- Extract `TourMarkerRequest` and `ReorderTourMarkersRequest` Form Request classes, replacing three inline `$request->validate()` calls (#450)
- Add 7 validation failure tests to `TourControllerTest`

## How to Test

Run the tour controller tests:
```
php artisan test --compact tests/Feature/TourControllerTest.php
```

## Closes

Closes #449
Closes #450