### PR TITLE
Delegate access check in TripService::getActiveTrip to findTripForUser (#452)

### DIFF
--- a/app/Services/TripService.php
+++ b/app/Services/TripService.php
@@ -28,7 +28,7 @@ class TripService
         if ($tripId) {
             try {
                 return $this->findTripForUser($user, $tripId);
-            } catch (\Throwable) {
+            } catch (ModelNotFoundException|AuthorizationException) {
                 // Fall through to the default trip when the trip is not found
                 // or the user does not have access to it.
             }

--- a/app/Services/TripService.php
+++ b/app/Services/TripService.php
@@ -26,21 +26,11 @@ class TripService
     public function getActiveTrip(User $user, ?int $tripId = null): Trip
     {
         if ($tripId) {
-            // Admins can access any trip directly
-            if ($user->isAdmin()) {
-                return Trip::findOrFail($tripId);
-            }
-
-            // Check owned trips first
-            $trip = $user->trips()->find($tripId);
-            if ($trip) {
-                return $trip;
-            }
-
-            // Check shared trips
-            $trip = $user->sharedTrips()->find($tripId);
-            if ($trip) {
-                return $trip;
+            try {
+                return $this->findTripForUser($user, $tripId);
+            } catch (\Throwable) {
+                // Fall through to the default trip when the trip is not found
+                // or the user does not have access to it.
             }
         }
 


### PR DESCRIPTION
## Summary

- `getActiveTrip()` previously duplicated the access-check logic from `findTripForUser()` by manually querying `trips()->find()` and `sharedTrips()->find()`
- Now delegates to `findTripForUser()` via a `try/catch`, preserving the silent fallback-to-default behaviour for callers that rely on it (e.g. `MarkerController::index` and `::store`)
- Removes 15 lines of duplicated logic; access rules are now maintained in a single place

## How to Test

```
php artisan test --compact tests/Feature/TripServiceTest.php tests/Feature/TripAdminManageTest.php
```

Closes #452