### PR TITLE
Fix Trip::hasAccess() N+1 by checking loaded relation cache first (#454)

### DIFF
--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -61,10 +61,19 @@ class Trip extends Model
 
     /**
      * Check if a user has access to this trip (is owner or shared user).
+     * Uses the already-loaded relation when available to avoid N+1 queries.
      */
     public function hasAccess(User $user): bool
     {
-        return $this->user_id === $user->id || $this->sharedUsers()->where('user_id', $user->id)->exists();
+        if ($this->user_id === $user->id) {
+            return true;
+        }
+
+        if ($this->relationLoaded('sharedUsers')) {
+            return $this->sharedUsers->contains($user);
+        }
+
+        return $this->sharedUsers()->where('user_id', $user->id)->exists();
     }
 
     /**

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -65,7 +65,7 @@ class Trip extends Model
      */
     public function hasAccess(User $user): bool
     {
-        if ($this->user_id === $user->id) {
+        if ($this->isOwner($user)) {
             return true;
         }
 

--- a/tests/Feature/TripHasAccessTest.php
+++ b/tests/Feature/TripHasAccessTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Models\Trip;
+use App\Models\User;
+
+test('hasAccess returns true for trip owner', function () {
+    $owner = User::factory()->withoutTwoFactor()->create();
+    $trip = Trip::factory()->create(['user_id' => $owner->id]);
+
+    expect($trip->hasAccess($owner))->toBeTrue();
+});
+
+test('hasAccess returns false for unrelated user', function () {
+    $owner = User::factory()->withoutTwoFactor()->create();
+    $other = User::factory()->withoutTwoFactor()->create();
+    $trip = Trip::factory()->create(['user_id' => $owner->id]);
+
+    expect($trip->hasAccess($other))->toBeFalse();
+});
+
+test('hasAccess returns true for shared user via db query', function () {
+    $owner = User::factory()->withoutTwoFactor()->create();
+    $collaborator = User::factory()->withoutTwoFactor()->create();
+    $trip = Trip::factory()->create(['user_id' => $owner->id]);
+    $trip->sharedUsers()->attach($collaborator->id);
+
+    expect($trip->hasAccess($collaborator))->toBeTrue();
+});
+
+test('hasAccess returns true for shared user when relation is already loaded', function () {
+    $owner = User::factory()->withoutTwoFactor()->create();
+    $collaborator = User::factory()->withoutTwoFactor()->create();
+    $trip = Trip::factory()->create(['user_id' => $owner->id]);
+    $trip->sharedUsers()->attach($collaborator->id);
+
+    // Eager-load the relation to exercise the in-memory path
+    $trip->load('sharedUsers');
+
+    expect($trip->hasAccess($collaborator))->toBeTrue();
+});
+
+test('hasAccess returns false for unrelated user when relation is already loaded', function () {
+    $owner = User::factory()->withoutTwoFactor()->create();
+    $other = User::factory()->withoutTwoFactor()->create();
+    $trip = Trip::factory()->create(['user_id' => $owner->id]);
+
+    // Eager-load the (empty) relation to exercise the in-memory path
+    $trip->load('sharedUsers');
+
+    expect($trip->hasAccess($other))->toBeFalse();
+});

--- a/tests/Feature/TripHasAccessTest.php
+++ b/tests/Feature/TripHasAccessTest.php
@@ -36,7 +36,13 @@ test('hasAccess returns true for shared user when relation is already loaded', f
     // Eager-load the relation to exercise the in-memory path
     $trip->load('sharedUsers');
 
+    $queryCount = 0;
+    \Illuminate\Support\Facades\DB::listen(function () use (&$queryCount) {
+        $queryCount++;
+    });
+
     expect($trip->hasAccess($collaborator))->toBeTrue();
+    expect($queryCount)->toBe(0);
 });
 
 test('hasAccess returns false for unrelated user when relation is already loaded', function () {
@@ -47,5 +53,11 @@ test('hasAccess returns false for unrelated user when relation is already loaded
     // Eager-load the (empty) relation to exercise the in-memory path
     $trip->load('sharedUsers');
 
+    $queryCount = 0;
+    \Illuminate\Support\Facades\DB::listen(function () use (&$queryCount) {
+        $queryCount++;
+    });
+
     expect($trip->hasAccess($other))->toBeFalse();
+    expect($queryCount)->toBe(0);
 });


### PR DESCRIPTION
## Summary

- `hasAccess()` previously always issued a `WHERE ... EXISTS` query even when `sharedUsers` was already eager-loaded
- Now checks `relationLoaded('sharedUsers')` first and uses the in-memory collection via `contains()`, falling back to the DB query only when the relation is not loaded
- Extracted the early-return owner check to make the intent clearer
- 5 feature tests covering all branches (owner, non-member, shared via DB, shared via loaded relation, non-member via loaded relation)

## How to Test

```
php artisan test --compact tests/Feature/TripHasAccessTest.php
```

Closes #454