### PR TITLE
Split MarkerData type: introduce MarkerApiData for API shape (#457)

### DIFF
--- a/resources/js/components/ai-recommendations-panel.tsx
+++ b/resources/js/components/ai-recommendations-panel.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Spinner } from '@/components/ui/spinner';
 import { useLanguage } from '@/hooks/use-language';
-import { MarkerData } from '@/types/marker';
+import { MarkerApiData } from '@/types/marker';
 import { Tour } from '@/types/tour';
 import { Bot, Map, MapPin, Route } from 'lucide-react';
 import { marked } from 'marked';
@@ -20,7 +20,7 @@ interface AiRecommendationsPanelProps {
     tripName: string | null;
     selectedTourId: number | null;
     tours: Tour[];
-    markers: MarkerData[];
+    markers: MarkerApiData[];
     mapBounds: MapBounds | null;
 }
 

--- a/resources/js/components/available-markers.tsx
+++ b/resources/js/components/available-markers.tsx
@@ -8,13 +8,13 @@ import {
 import { Icon } from '@/components/ui/icon';
 import { getMarkerTypeIcon, UnescoIcon } from '@/lib/marker-icons';
 import { cn } from '@/lib/utils';
-import { MarkerData } from '@/types/marker';
+import { MarkerApiData } from '@/types/marker';
 import { ChevronDown, Plus } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 interface AvailableMarkersProps {
     /** All markers that can be added to the tour (including those already in tour) */
-    availableMarkers: MarkerData[];
+    availableMarkers: MarkerApiData[];
     /** ID of the currently selected available marker (for blue ring highlight) */
     selectedAvailableMarkerId: string | null;
     /** Callback when an available marker is clicked to select it */

--- a/resources/js/components/route-panel.tsx
+++ b/resources/js/components/route-panel.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/lib/route-calculations';
 import { formatDuration } from '@/lib/route-formatting';
 import { getTransportColor, getTransportIcon } from '@/lib/transport-utils';
-import { MarkerData } from '@/types/marker';
+import { MarkerApiData } from '@/types/marker';
 import { Route, TransportMode } from '@/types/route';
 import { Tour } from '@/types/tour';
 import axios from 'axios';
@@ -43,7 +43,7 @@ import { toast } from 'sonner';
 interface RoutePanelProps {
     tripId: number;
     tourId?: number | null;
-    markers: MarkerData[];
+    markers: MarkerApiData[];
     routes: Route[];
     onRoutesUpdate: (routes: Route[]) => void;
     initialStartMarkerId?: string;

--- a/resources/js/components/tour-panel.tsx
+++ b/resources/js/components/tour-panel.tsx
@@ -5,7 +5,7 @@ import { Icon } from '@/components/ui/icon';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { getMarkerTypeIcon, UnescoIcon } from '@/lib/marker-icons';
 import { formatDuration } from '@/lib/utils';
-import { MarkerData } from '@/types/marker';
+import { MarkerApiData } from '@/types/marker';
 import { Route } from '@/types/route';
 import { Tour } from '@/types/tour';
 import {
@@ -24,7 +24,7 @@ interface TourPanelProps {
     onSelectTour: (tourId: number | null) => void;
     onCreateTour: () => void;
     onDeleteTour: (tourId: number) => void;
-    markers: MarkerData[];
+    markers: MarkerApiData[];
     routes: Route[];
     onMoveMarkerUp?: (markerId: string) => void;
     onMoveMarkerDown?: (markerId: string) => void;
@@ -62,7 +62,7 @@ function TourTab({ tour, markerCount }: TourTabProps) {
 }
 
 interface MarkerItemProps {
-    marker: MarkerData;
+    marker: MarkerApiData;
     index: number;
     isFirst: boolean;
     isLast: boolean;
@@ -166,8 +166,8 @@ function MarkerItem({
 
 interface TourCardProps {
     tour: Tour;
-    markers: MarkerData[];
-    allMarkers: MarkerData[];
+    markers: MarkerApiData[];
+    allMarkers: MarkerApiData[];
     routes: Route[];
     onDeleteTour: (tourId: number) => void;
     onMoveMarkerUp?: (markerId: string) => void;
@@ -392,7 +392,7 @@ export default function TourPanel({
               .map((tourMarker) =>
                   markers.find((marker) => marker.id === tourMarker.id),
               )
-              .filter((marker): marker is MarkerData => marker !== undefined)
+              .filter((marker): marker is MarkerApiData => marker !== undefined)
         : [];
 
     return (

--- a/resources/js/hooks/use-tour-lines.ts
+++ b/resources/js/hooks/use-tour-lines.ts
@@ -2,7 +2,7 @@ import {
     ensureVectorLayerOrder,
     getFirstSymbolLayerId,
 } from '@/lib/map-layers';
-import { MarkerData } from '@/types/marker';
+import { MarkerApiData } from '@/types/marker';
 import { Route } from '@/types/route';
 import { Tour } from '@/types/tour';
 import mapboxgl from 'mapbox-gl';
@@ -12,7 +12,7 @@ interface UseTourLinesOptions {
     mapInstance: mapboxgl.Map | null;
     selectedTourId: number | null;
     tours: Tour[];
-    markers: MarkerData[];
+    markers: MarkerApiData[];
     routes: Route[];
     onTourLineClick?: (startMarkerId: string, endMarkerId: string) => void;
 }
@@ -112,7 +112,7 @@ export function useTourLines({
             .map((tourMarker) =>
                 markers.find((marker) => marker.id === tourMarker.id),
             )
-            .filter((marker): marker is MarkerData => marker !== undefined);
+            .filter((marker): marker is MarkerApiData => marker !== undefined);
 
         // Draw lines between consecutive markers
         for (let i = 0; i < tourMarkers.length - 1; i++) {

--- a/resources/js/types/marker.ts
+++ b/resources/js/types/marker.ts
@@ -19,7 +19,11 @@ export enum MarkerType {
     Haltestelle = 'haltestelle',
 }
 
-export interface MarkerData {
+/**
+ * Pure API response shape — no live Mapbox instances.
+ * Use this type for data received from or sent to the backend.
+ */
+export interface MarkerApiData {
     id: string; // UUID - same as database ID
     lat: number;
     lng: number;
@@ -31,7 +35,14 @@ export interface MarkerData {
     isUnesco: boolean;
     aiEnriched: boolean;
     estimatedHours: number | null;
-    marker: mapboxgl.Marker;
     isSaved: boolean; // Track if marker is persisted in database
     position?: number; // Position in tour (when part of a tour)
+}
+
+/**
+ * Runtime marker state — extends the API shape with a live Mapbox marker instance.
+ * Use this type within the map UI where the Mapbox instance is available.
+ */
+export interface MarkerData extends MarkerApiData {
+    marker: mapboxgl.Marker;
 }

--- a/resources/js/types/marker.ts
+++ b/resources/js/types/marker.ts
@@ -1,4 +1,4 @@
-import mapboxgl from 'mapbox-gl';
+import type mapboxgl from 'mapbox-gl';
 
 export enum MarkerType {
     Restaurant = 'restaurant',
@@ -20,8 +20,9 @@ export enum MarkerType {
 }
 
 /**
- * Pure API response shape — no live Mapbox instances.
- * Use this type for data received from or sent to the backend.
+ * Frontend-normalized marker data shape (camelCase fields), without a live Mapbox instance.
+ * Use this type for marker data after mapping/parsing backend responses or before preparing
+ * payloads to send, not as the raw backend DTO shape.
  */
 export interface MarkerApiData {
     id: string; // UUID - same as database ID

--- a/resources/js/types/tour.ts
+++ b/resources/js/types/tour.ts
@@ -1,4 +1,4 @@
-import { MarkerData } from './marker';
+import { MarkerApiData } from './marker';
 
 export interface Tour {
     id: number;
@@ -7,5 +7,5 @@ export interface Tour {
     created_at: string;
     updated_at: string;
     estimated_duration_hours?: number;
-    markers?: MarkerData[];
+    markers?: MarkerApiData[];
 }


### PR DESCRIPTION
## Summary

- Introduces `MarkerApiData` interface for the pure API response shape (no Mapbox instances)
- `MarkerData` now `extends MarkerApiData` and adds `marker: mapboxgl.Marker` for runtime state
- Updates `Tour.markers` to use `MarkerApiData[]` (API data never carries live Mapbox instances)
- Updates 5 components/hooks that only use pure data fields to accept `MarkerApiData` instead of `MarkerData`

## Changed files

- `resources/js/types/marker.ts` — adds `MarkerApiData`, makes `MarkerData extends MarkerApiData`
- `resources/js/types/tour.ts` — `markers?: MarkerApiData[]`
- `resources/js/components/tour-panel.tsx` — `MarkerData[]` → `MarkerApiData[]`
- `resources/js/components/route-panel.tsx` — `MarkerData[]` → `MarkerApiData[]`
- `resources/js/components/ai-recommendations-panel.tsx` — `MarkerData[]` → `MarkerApiData[]`
- `resources/js/components/available-markers.tsx` — `MarkerData[]` → `MarkerApiData[]`
- `resources/js/hooks/use-tour-lines.ts` — `MarkerData[]` → `MarkerApiData[]`

Files that create or manipulate live Mapbox instances (`use-markers.ts`, `use-marker-styling.ts`, `use-geocoder.ts`, `use-map-interactions.ts`, `use-search-results.ts`, `marker-form` family) continue to use `MarkerData`.

## Testing

Zero new TypeScript errors. All 635 passing tests continue to pass.

Closes #457