### PR TITLE
Fix startup_failure in deploy pipelines after #479

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -13,6 +13,9 @@ jobs:
   # Zuerst Tests ausführen
   tests:
     uses: ./.github/workflows/tests.yml
+    permissions:
+      checks: write
+      contents: read
 
   # Deployment (nur wenn Tests erfolgreich)
   deploy:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,6 +10,9 @@ jobs:
   # Zuerst Tests ausführen
   tests:
     uses: ./.github/workflows/tests.yml
+    permissions:
+      checks: write
+      contents: read
 
   # Deployment (nur wenn Tests erfolgreich)
   deploy:


### PR DESCRIPTION
## Summary

- Adds `permissions: checks: write / contents: read` to the `tests` job in both `deploy-dev.yml` and `deploy-prod.yml`
- Same fix as applied to `ci.yml` in #480 — `workflow_call` callers must explicitly grant any permissions the called workflow requires

## Root cause

`tests.yml` now contains a `browser-tests` job that requires `checks: write`. When called via `workflow_call`, GitHub only grants the permissions the caller explicitly lists. Both deploy pipelines had only `contents: read` at the top level, causing a `startup_failure` before any job could run.

Closes #478