### PR TITLE
feat(map): show trip name and admin highlight in toolbar (#482)

### DIFF
--- a/app/Http/Controllers/MapController.php
+++ b/app/Http/Controllers/MapController.php
@@ -21,6 +21,7 @@ class MapController extends Controller
             [
                 'trip' => [
                     'id' => $trip->id,
+                    'name' => $trip->name,
                 ],
             ],
             $this->buildAdminOwnerProps($trip),

--- a/resources/js/components/map-container.tsx
+++ b/resources/js/components/map-container.tsx
@@ -1,5 +1,5 @@
 import TravelMap from '@/components/travel-map';
-import { TripOwner } from '@/types';
+import { type TripOwner } from '@/types';
 import { Tour } from '@/types/tour';
 import { Trip } from '@/types/trip';
 import { Dispatch, SetStateAction } from 'react';

--- a/resources/js/components/map-container.tsx
+++ b/resources/js/components/map-container.tsx
@@ -1,4 +1,5 @@
 import TravelMap from '@/components/travel-map';
+import { TripOwner } from '@/types';
 import { Tour } from '@/types/tour';
 import { Trip } from '@/types/trip';
 import { Dispatch, SetStateAction } from 'react';
@@ -18,6 +19,8 @@ interface MapContainerProps {
         tripId: number,
         viewport: { latitude: number; longitude: number; zoom: number },
     ) => Promise<void>;
+    tripName?: string;
+    owner?: TripOwner;
 }
 
 export function MapContainer({
@@ -32,6 +35,8 @@ export function MapContainer({
     onCreateTour,
     onDeleteTour,
     onSetViewport,
+    tripName,
+    owner,
 }: MapContainerProps) {
     return (
         <div className="fixed inset-0 h-screen w-screen overflow-hidden">
@@ -47,6 +52,8 @@ export function MapContainer({
                 onCreateTour={onCreateTour}
                 onDeleteTour={onDeleteTour}
                 onSetViewport={onSetViewport}
+                tripName={tripName}
+                owner={owner}
             />
         </div>
     );

--- a/resources/js/components/toolbar.tsx
+++ b/resources/js/components/toolbar.tsx
@@ -16,7 +16,7 @@ import {
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { Slider } from '@/components/ui/slider';
 import { useLanguage } from '@/hooks/use-language';
-import { TripOwner } from '@/types';
+import { type TripOwner } from '@/types';
 import { SearchBoxRetrieveResponse } from '@mapbox/search-js-core';
 import { SearchBox } from '@mapbox/search-js-react';
 import { Settings } from 'lucide-react';

--- a/resources/js/components/toolbar.tsx
+++ b/resources/js/components/toolbar.tsx
@@ -16,6 +16,7 @@ import {
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { Slider } from '@/components/ui/slider';
 import { useLanguage } from '@/hooks/use-language';
+import { TripOwner } from '@/types';
 import { SearchBoxRetrieveResponse } from '@mapbox/search-js-core';
 import { SearchBox } from '@mapbox/search-js-react';
 import { Settings } from 'lucide-react';
@@ -39,6 +40,8 @@ interface ToolbarProps {
     placeTypes?: PlaceType[];
     selectedPlaceType?: string;
     onPlaceTypeChange?: (placeType: string) => void;
+    tripName?: string;
+    owner?: TripOwner;
 }
 
 /**
@@ -56,6 +59,8 @@ export function Toolbar({
     placeTypes = [],
     selectedPlaceType = '',
     onPlaceTypeChange,
+    tripName,
+    owner,
 }: ToolbarProps) {
     const { language } = useLanguage();
     const [isOptionsOpen, setIsOptionsOpen] = useState(false);
@@ -87,6 +92,26 @@ export function Toolbar({
                     data-testid="sidebar-trigger"
                 />
             </div>
+
+            {/* Trip Name */}
+            {tripName && (
+                <div className="flex min-w-0 shrink-0 flex-col justify-center">
+                    {owner ? (
+                        <div className="flex flex-col gap-0.5">
+                            <span className="max-w-[160px] truncate rounded-sm border border-red-300 bg-red-100 px-2 py-0.5 text-sm font-semibold text-red-800 dark:border-red-700 dark:bg-red-900 dark:text-red-200">
+                                {tripName}
+                            </span>
+                            <span className="max-w-[160px] truncate px-2 text-xs text-red-600 dark:text-red-400">
+                                von {owner.name}
+                            </span>
+                        </div>
+                    ) : (
+                        <span className="max-w-[200px] truncate text-sm font-medium text-gray-700 dark:text-gray-300">
+                            {tripName}
+                        </span>
+                    )}
+                </div>
+            )}
 
             {/* Search Box */}
             {accessToken && (

--- a/resources/js/components/travel-map/index.tsx
+++ b/resources/js/components/travel-map/index.tsx
@@ -22,7 +22,7 @@ import { useTourLines } from '@/hooks/use-tour-lines';
 import { useTourMarkers } from '@/hooks/use-tour-markers';
 import { useTripNotes } from '@/hooks/use-trip-notes';
 import { getBoundingBoxFromTrip } from '@/lib/map-utils';
-import { TripOwner } from '@/types';
+import { type TripOwner } from '@/types';
 import { Route } from '@/types/route';
 import { Tour } from '@/types/tour';
 import { Trip } from '@/types/trip';

--- a/resources/js/components/travel-map/index.tsx
+++ b/resources/js/components/travel-map/index.tsx
@@ -22,6 +22,7 @@ import { useTourLines } from '@/hooks/use-tour-lines';
 import { useTourMarkers } from '@/hooks/use-tour-markers';
 import { useTripNotes } from '@/hooks/use-trip-notes';
 import { getBoundingBoxFromTrip } from '@/lib/map-utils';
+import { TripOwner } from '@/types';
 import { Route } from '@/types/route';
 import { Tour } from '@/types/tour';
 import { Trip } from '@/types/trip';
@@ -49,6 +50,8 @@ interface TravelMapProps {
         tripId: number,
         viewport: { latitude: number; longitude: number; zoom: number },
     ) => Promise<void>;
+    tripName?: string;
+    owner?: TripOwner;
 }
 
 /**
@@ -76,6 +79,8 @@ export default function TravelMap({
     onCreateTour,
     onDeleteTour,
     onSetViewport,
+    tripName,
+    owner,
 }: TravelMapProps) {
     // Detect mobile/desktop breakpoint
     const { isMobileLayout } = useBreakpoint();
@@ -364,6 +369,8 @@ export default function TravelMap({
                 placeTypes={placeTypes}
                 selectedPlaceType={selectedPlaceType}
                 onPlaceTypeChange={setSelectedPlaceType}
+                tripName={tripName}
+                owner={owner}
             />
 
             {/* Map fills the entire screen */}

--- a/resources/js/pages/map.tsx
+++ b/resources/js/pages/map.tsx
@@ -18,7 +18,7 @@ type MapPageProps = SharedData & {
 };
 
 export default function MapPage() {
-    const { trip, owner, auth } = usePage<MapPageProps>().props;
+    const { trip, owner } = usePage<MapPageProps>().props;
     const { t } = useTranslation();
 
     const breadcrumbs: BreadcrumbItem[] = [

--- a/resources/js/pages/map.tsx
+++ b/resources/js/pages/map.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 type MapPageProps = SharedData & {
     trip?: {
         id: number;
+        name: string;
     };
     owner?: TripOwner;
 };
@@ -108,11 +109,6 @@ export default function MapPage() {
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Map" />
-            {auth.user?.role === 'admin' && owner && (
-                <div className="flex items-center gap-2 border-b border-red-200 bg-red-50 px-4 py-2 text-sm font-medium text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200">
-                    <span>Du bearbeitest die Reise von {owner.name}</span>
-                </div>
-            )}
             <MapContainer
                 selectedTripId={selectedTripId}
                 selectedTourId={selectedTourId}
@@ -125,6 +121,8 @@ export default function MapPage() {
                 onCreateTour={openCreateTourModal}
                 onDeleteTour={handleOpenDeleteTourDialog}
                 onSetViewport={handleSetViewport}
+                tripName={trip?.name}
+                owner={owner}
             />
             <ModalManager
                 isCreateTripModalOpen={modalState.isCreateTripModalOpen}

--- a/resources/js/pages/map.tsx
+++ b/resources/js/pages/map.tsx
@@ -121,7 +121,10 @@ export default function MapPage() {
                 onCreateTour={openCreateTourModal}
                 onDeleteTour={handleOpenDeleteTourDialog}
                 onSetViewport={handleSetViewport}
-                tripName={trip?.name}
+                tripName={
+                    trips.find((t) => t.id === selectedTripId)?.name ??
+                    trip?.name
+                }
                 owner={owner}
             />
             <ModalManager

--- a/tests/Feature/MapControllerTest.php
+++ b/tests/Feature/MapControllerTest.php
@@ -17,6 +17,7 @@ test('owner can view the map for their trip', function () {
             ->component('map')
             ->has('trip')
             ->where('trip.id', $trip->id)
+            ->where('trip.name', $trip->name)
             ->missing('owner')
         );
 });
@@ -76,6 +77,7 @@ test('admin viewing another user trip receives owner prop for banner', function 
         ->assertInertia(fn ($page) => $page
             ->component('map')
             ->where('trip.id', $trip->id)
+            ->where('trip.name', $trip->name)
             ->has('owner')
             ->where('owner.id', $owner->id)
             ->where('owner.name', $owner->name)


### PR DESCRIPTION
## Summary

- Zeigt den Namen der aktuell geöffneten Reise in der Toolbar zwischen SidebarTrigger und Suchfeld an
- Bei langen Namen wird der Text abgeschnitten (truncated)
- Admins, die eine fremde Reise öffnen, sehen den Reisenamen mit rotem Badge/Border sowie den Namen des Reiseinhabers darunter
- Das bisherige rote Admin-Banner unterhalb der Toolbar wurde entfernt (Information ist jetzt in der Toolbar integriert)

## Änderungen

- `MapController::show()`: `trip.name` wird zusätzlich zu `trip.id` an Inertia übergeben
- `map.tsx`: Typ um `trip.name` erweitert; Admin-Banner entfernt; `owner` und `tripName` werden an `MapContainer` weitergegeben
- `map-container.tsx`: Props `tripName` und `owner` durchgereicht an `TravelMap`
- `travel-map/index.tsx`: Props `tripName` und `owner` bis zur `Toolbar` weitergegeben
- `toolbar.tsx`: Neuer UI-Block zwischen SidebarTrigger und Suchfeld — normaler Fall: einfacher Reisename; Admin-Fall: roter Badge mit Reisename + „von {owner.name}"
- Tests aktualisiert um `trip.name` in den Assertions zu prüfen

## Testen

1. Eine Reise öffnen → Reisename erscheint in der Toolbar
2. Als Admin eine fremde Reise öffnen → Roter Badge mit Reisename und Inhabername erscheint; kein separates Banner mehr
3. Als Admin eigene Reise öffnen → normaler Reisename ohne Hervorhebung

Closes #482