### PR TITLE
feat: alternative transit route selection and adoption (#315)

### DIFF
--- a/app/Http/Controllers/RouteController.php
+++ b/app/Http/Controllers/RouteController.php
@@ -8,6 +8,7 @@ use App\Exceptions\RouteNotFoundException;
 use App\Exceptions\RoutingProviderException;
 use App\Http\Requests\RouteIndexRequest;
 use App\Http\Requests\StoreRouteRequest;
+use App\Http\Requests\UpdateRouteAlternativeRequest;
 use App\Http\Resources\RouteResource;
 use App\Models\Marker;
 use App\Models\Route;
@@ -99,5 +100,35 @@ class RouteController extends Controller
         $route->delete();
 
         return response()->json(null, 204);
+    }
+
+    public function updateAlternative(UpdateRouteAlternativeRequest $request, Route $route): JsonResponse
+    {
+        $this->authorize('update', $route->trip);
+
+        if ($route->transport_mode !== TransportMode::PublicTransport) {
+            return response()->json(['error' => 'Alternative selection is only available for public transport routes'], 422);
+        }
+
+        $alternatives = $route->alternatives ?? [];
+        $index = $request->validated()['alternative_index'];
+
+        if ($index >= count($alternatives)) {
+            return response()->json(['error' => 'Alternative index out of range'], 422);
+        }
+
+        $chosen = $alternatives[$index];
+
+        $route->update([
+            'distance' => $chosen['distance'],
+            'duration' => $chosen['duration'],
+            'geometry' => $chosen['geometry'] ?? $route->geometry,
+            'transit_details' => $chosen['transit_details'] ?? $route->transit_details,
+            'alternatives' => null,
+        ]);
+
+        $route->load(['startMarker', 'endMarker']);
+
+        return response()->json(new RouteResource($route));
     }
 }

--- a/app/Http/Requests/UpdateRouteAlternativeRequest.php
+++ b/app/Http/Requests/UpdateRouteAlternativeRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRouteAlternativeRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'alternative_index' => 'required|integer|min:0',
+        ];
+    }
+}

--- a/app/Services/RoutingService.php
+++ b/app/Services/RoutingService.php
@@ -285,6 +285,7 @@ class RoutingService
 
     /**
      * Extract alternative routes information from Google Routes API v2.
+     * Includes geometry and transit_details so alternatives can be adopted as the primary route.
      */
     private function extractAlternativeRoutesV2(array $routes): array
     {
@@ -293,18 +294,29 @@ class RoutingService
             $duration = (int) rtrim($route['duration'], 's');
 
             $numTransfers = 0;
+            $geometry = null;
+            $transitDetails = null;
+
             if (isset($route['legs'][0]['steps'])) {
                 $transitSteps = array_filter(
                     $route['legs'][0]['steps'],
                     fn ($step) => ($step['travelMode'] ?? '') === 'TRANSIT'
                 );
                 $numTransfers = max(0, count($transitSteps) - 1);
+
+                $transitDetails = $this->extractTransitDetailsV2($route['legs'][0]);
+            }
+
+            if (isset($route['polyline']['encodedPolyline'])) {
+                $geometry = $this->decodePolyline($route['polyline']['encodedPolyline']);
             }
 
             return [
                 'distance' => $distance,
                 'duration' => $duration,
                 'num_transfers' => $numTransfers,
+                'geometry' => $geometry,
+                'transit_details' => $transitDetails,
             ];
         }, $routes);
     }

--- a/resources/js/components/route-panel.tsx
+++ b/resources/js/components/route-panel.tsx
@@ -643,8 +643,7 @@ export default function RoutePanel({
                                                                         selectedIndex={
                                                                             highlightedRouteId ===
                                                                             route.id
-                                                                                ? (selectedAlternativeIndex ??
-                                                                                  null)
+                                                                                ? selectedAlternativeIndex
                                                                                 : null
                                                                         }
                                                                         isAdopting={

--- a/resources/js/components/route-panel.tsx
+++ b/resources/js/components/route-panel.tsx
@@ -54,6 +54,11 @@ interface RoutePanelProps {
     onExpandedRoutesChange: (expandedRoutes: Set<number>) => void;
     onHighlightedRouteIdChange?: (routeId: number | null) => void;
     onTourUpdate?: (tour: Tour) => void;
+    selectedAlternativeIndex?: number | null;
+    onSelectedAlternativeIndexChange?: (
+        routeId: number | null,
+        index: number | null,
+    ) => void;
 }
 
 export default function RoutePanel({
@@ -70,6 +75,8 @@ export default function RoutePanel({
     onExpandedRoutesChange,
     onHighlightedRouteIdChange,
     onTourUpdate,
+    selectedAlternativeIndex = null,
+    onSelectedAlternativeIndexChange,
 }: RoutePanelProps) {
     const [startMarkerId, setStartMarkerId] =
         useState<string>(initialStartMarkerId);
@@ -78,6 +85,7 @@ export default function RoutePanel({
         useState<TransportMode>('driving-car');
     const [isCreating, setIsCreating] = useState(false);
     const [isSorting, setIsSorting] = useState(false);
+    const [isAdopting, setIsAdopting] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [deleteRouteId, setDeleteRouteId] = useState<number | null>(null);
     const [showOptimizeTourDialog, setShowOptimizeTourDialog] = useState(false);
@@ -245,6 +253,34 @@ export default function RoutePanel({
             setShowOptimizeTourDialog(false);
         } finally {
             setIsSorting(false);
+        }
+    };
+
+    const handleAdoptAlternative = async (route: Route) => {
+        if (selectedAlternativeIndex === null) return;
+
+        setIsAdopting(true);
+        try {
+            const response = await axios.patch(
+                `/routes/${route.id}/alternative`,
+                { alternative_index: selectedAlternativeIndex },
+                {
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Accept: 'application/json',
+                    },
+                },
+            );
+            onRoutesUpdate(
+                routes.map((r) => (r.id === route.id ? response.data : r)),
+            );
+            onSelectedAlternativeIndexChange?.(null, null);
+            toast.success('Route updated successfully');
+        } catch (err) {
+            console.error('Failed to adopt alternative route:', err);
+            toast.error('Failed to adopt alternative route. Please try again.');
+        } finally {
+            setIsAdopting(false);
         }
     };
 
@@ -603,6 +639,29 @@ export default function RoutePanel({
                                                                     <AlternativeRoutesList
                                                                         alternatives={
                                                                             route.alternatives
+                                                                        }
+                                                                        selectedIndex={
+                                                                            highlightedRouteId ===
+                                                                            route.id
+                                                                                ? (selectedAlternativeIndex ??
+                                                                                  null)
+                                                                                : null
+                                                                        }
+                                                                        isAdopting={
+                                                                            isAdopting
+                                                                        }
+                                                                        onSelect={(
+                                                                            index,
+                                                                        ) =>
+                                                                            onSelectedAlternativeIndexChange?.(
+                                                                                route.id,
+                                                                                index,
+                                                                            )
+                                                                        }
+                                                                        onAdopt={() =>
+                                                                            handleAdoptAlternative(
+                                                                                route,
+                                                                            )
                                                                         }
                                                                     />
                                                                 </>

--- a/resources/js/components/route-panel/alternative-routes-list.tsx
+++ b/resources/js/components/route-panel/alternative-routes-list.tsx
@@ -31,11 +31,13 @@ export function AlternativeRoutesList({
             <h5 className="text-sm font-semibold">
                 Alternative routes ({alternatives.length})
             </h5>
-            <div className="space-y-2">
+            <div className="space-y-2" role="radiogroup">
                 {alternatives.map((alt, index) => (
                     <button
                         key={index}
                         type="button"
+                        role="radio"
+                        aria-checked={selectedIndex === index}
                         onClick={() => onSelect(index)}
                         className={cn(
                             'flex w-full cursor-pointer items-center justify-between rounded-md border p-2 text-xs transition-colors',

--- a/resources/js/components/route-panel/alternative-routes-list.tsx
+++ b/resources/js/components/route-panel/alternative-routes-list.tsx
@@ -1,17 +1,28 @@
 /**
- * Component for displaying alternative public transport routes
- * Shows list of alternative route options with distance, duration and transfers
+ * Component for selecting alternative public transport routes.
+ * Allows the user to pick an alternative and adopt it as the primary route.
  */
 
+import { Button } from '@/components/ui/button';
 import { formatDurationFromSeconds } from '@/lib/route-formatting';
-import { AlternativeRoute } from '@/types/route';
+import { cn } from '@/lib/utils';
+import { type AlternativeRoute } from '@/types/route';
+import { Check } from 'lucide-react';
 
 interface AlternativeRoutesListProps {
     alternatives: AlternativeRoute[] | null;
+    selectedIndex: number | null;
+    isAdopting: boolean;
+    onSelect: (index: number) => void;
+    onAdopt: () => void;
 }
 
 export function AlternativeRoutesList({
     alternatives,
+    selectedIndex,
+    isAdopting,
+    onSelect,
+    onAdopt,
 }: AlternativeRoutesListProps) {
     if (!alternatives || alternatives.length === 0) return null;
 
@@ -22,9 +33,16 @@ export function AlternativeRoutesList({
             </h5>
             <div className="space-y-2">
                 {alternatives.map((alt, index) => (
-                    <div
+                    <button
                         key={index}
-                        className="flex items-center justify-between rounded-md bg-background p-2 text-xs"
+                        type="button"
+                        onClick={() => onSelect(index)}
+                        className={cn(
+                            'flex w-full cursor-pointer items-center justify-between rounded-md border p-2 text-xs transition-colors',
+                            selectedIndex === index
+                                ? 'border-blue-500 bg-blue-50 dark:border-blue-400 dark:bg-blue-950/30'
+                                : 'border-transparent bg-background hover:border-muted-foreground/30 hover:bg-muted',
+                        )}
                     >
                         <span className="font-medium">Option {index + 2}</span>
                         <div className="flex items-center gap-3 text-muted-foreground">
@@ -40,10 +58,24 @@ export function AlternativeRoutesList({
                                     ? 'transfer'
                                     : 'transfers'}
                             </span>
+                            {selectedIndex === index && (
+                                <Check className="h-3 w-3 text-blue-500" />
+                            )}
                         </div>
-                    </div>
+                    </button>
                 ))}
             </div>
+
+            {selectedIndex !== null && (
+                <Button
+                    size="sm"
+                    className="mt-2 w-full"
+                    disabled={isAdopting}
+                    onClick={onAdopt}
+                >
+                    {isAdopting ? 'Adopting...' : 'Adopt this route'}
+                </Button>
+            )}
         </div>
     );
 }

--- a/resources/js/components/travel-map/desktop-panels.tsx
+++ b/resources/js/components/travel-map/desktop-panels.tsx
@@ -66,6 +66,11 @@ interface DesktopPanelsProps {
     ) => void;
     setHighlightedRouteId: (id: number | null) => void;
     handleRequestRoute: (startMarkerId: string, endMarkerId: string) => void;
+    selectedAlternativeIndex: number | null;
+    onSelectedAlternativeIndexChange: (
+        routeId: number | null,
+        index: number | null,
+    ) => void;
 
     // Available marker selection (for tours)
     selectedAvailableMarkerId: string | null;
@@ -122,6 +127,8 @@ export function DesktopPanels({
     handleAddAvailableMarkerToTour,
     selectedTrip,
     mapBounds,
+    selectedAlternativeIndex,
+    onSelectedAlternativeIndexChange,
 }: DesktopPanelsProps) {
     const { t } = useTranslation();
 
@@ -251,6 +258,10 @@ export function DesktopPanels({
                         onExpandedRoutesChange={setExpandedRoutes}
                         onHighlightedRouteIdChange={setHighlightedRouteId}
                         onTourUpdate={handleTourUpdate}
+                        selectedAlternativeIndex={selectedAlternativeIndex}
+                        onSelectedAlternativeIndexChange={
+                            onSelectedAlternativeIndexChange
+                        }
                     />
                 </FloatingPanel>
             )}

--- a/resources/js/components/travel-map/index.tsx
+++ b/resources/js/components/travel-map/index.tsx
@@ -33,6 +33,7 @@ import {
     useCallback,
     useEffect,
     useRef,
+    useState,
 } from 'react';
 
 interface TravelMapProps {
@@ -189,6 +190,22 @@ export default function TravelMap({
         togglePanel,
     });
 
+    // Alternative route selection state — tracks which alternative is currently
+    // selected for a given expanded public transport route
+    const [selectedAlternativeRouteId, setSelectedAlternativeRouteId] =
+        useState<number | null>(null);
+    const [selectedAlternativeIndex, setSelectedAlternativeIndex] = useState<
+        number | null
+    >(null);
+
+    const handleSelectedAlternativeIndexChange = useCallback(
+        (routeId: number | null, index: number | null) => {
+            setSelectedAlternativeRouteId(routeId);
+            setSelectedAlternativeIndex(index);
+        },
+        [],
+    );
+
     // Routes management - now with proper route click handler
     const { routes, setRoutes } = useRoutes({
         mapInstance,
@@ -197,10 +214,17 @@ export default function TravelMap({
         tours,
         expandedRoutes,
         highlightedRouteId,
+        selectedAlternativeIndex:
+            highlightedRouteId === selectedAlternativeRouteId
+                ? selectedAlternativeIndex
+                : null,
         onRouteClick: (routeId: number) => {
             if (handleRouteClickRef.current) {
                 handleRouteClickRef.current(routeId);
             }
+        },
+        onAlternativeClick: (routeId: number, index: number) => {
+            handleSelectedAlternativeIndexChange(routeId, index);
         },
     });
 
@@ -351,6 +375,11 @@ export default function TravelMap({
         handleAddAvailableMarkerToTour,
         selectedTrip,
         mapBounds,
+        selectedAlternativeIndex:
+            highlightedRouteId === selectedAlternativeRouteId
+                ? selectedAlternativeIndex
+                : null,
+        onSelectedAlternativeIndexChange: handleSelectedAlternativeIndexChange,
     };
 
     return (

--- a/resources/js/components/travel-map/mobile-panels.tsx
+++ b/resources/js/components/travel-map/mobile-panels.tsx
@@ -66,6 +66,11 @@ interface MobilePanelsProps {
     ) => void;
     setHighlightedRouteId: (id: number | null) => void;
     handleRequestRoute: (startMarkerId: string, endMarkerId: string) => void;
+    selectedAlternativeIndex: number | null;
+    onSelectedAlternativeIndexChange: (
+        routeId: number | null,
+        index: number | null,
+    ) => void;
 
     // Available marker selection (for tours)
     selectedAvailableMarkerId: string | null;
@@ -122,6 +127,8 @@ export function MobilePanels({
     handleAddAvailableMarkerToTour,
     selectedTrip,
     mapBounds,
+    selectedAlternativeIndex,
+    onSelectedAlternativeIndexChange,
 }: MobilePanelsProps) {
     const { t } = useTranslation();
 
@@ -226,6 +233,10 @@ export function MobilePanels({
                             onExpandedRoutesChange={setExpandedRoutes}
                             onHighlightedRouteIdChange={setHighlightedRouteId}
                             onTourUpdate={handleTourUpdate}
+                            selectedAlternativeIndex={selectedAlternativeIndex}
+                            onSelectedAlternativeIndexChange={
+                                onSelectedAlternativeIndexChange
+                            }
                         />
                     </DraggableSheet>
                 )}

--- a/resources/js/hooks/use-routes.ts
+++ b/resources/js/hooks/use-routes.ts
@@ -15,7 +15,9 @@ interface UseRoutesOptions {
     tours: Tour[];
     expandedRoutes: Set<number>;
     highlightedRouteId?: number | null;
+    selectedAlternativeIndex?: number | null;
     onRouteClick?: (routeId: number) => void;
+    onAlternativeClick?: (routeId: number, index: number) => void;
 }
 
 export function useRoutes({
@@ -25,17 +27,25 @@ export function useRoutes({
     tours,
     expandedRoutes,
     highlightedRouteId,
+    selectedAlternativeIndex,
     onRouteClick,
+    onAlternativeClick,
 }: UseRoutesOptions) {
     const [routes, setRoutes] = useState<Route[]>([]);
     const routeLayerIdsRef = useRef<Map<number, string>>(new Map());
     const transitStopLayerIdsRef = useRef<Map<number, string>>(new Map());
-    const onRouteClickRef = useRef(onRouteClick); // Store callback in ref to avoid re-rendering
+    const alternativeLayerIdsRef = useRef<Map<string, string>>(new Map());
+    const onRouteClickRef = useRef(onRouteClick);
+    const onAlternativeClickRef = useRef(onAlternativeClick);
 
     // Update ref when callback changes
     useEffect(() => {
         onRouteClickRef.current = onRouteClick;
     }, [onRouteClick]);
+
+    useEffect(() => {
+        onAlternativeClickRef.current = onAlternativeClick;
+    }, [onAlternativeClick]);
 
     // Load routes from database when trip changes
     useEffect(() => {
@@ -86,6 +96,17 @@ export function useRoutes({
             }
         });
         transitStopLayerIdsRef.current.clear();
+
+        // Clear existing alternative route layers
+        alternativeLayerIdsRef.current.forEach((layerId) => {
+            if (mapInstance.getLayer(layerId)) {
+                mapInstance.removeLayer(layerId);
+            }
+            if (mapInstance.getSource(layerId)) {
+                mapInstance.removeSource(layerId);
+            }
+        });
+        alternativeLayerIdsRef.current.clear();
 
         // Filter routes by selected tour (if a tour is selected)
         // If no tour is selected, only show expanded routes
@@ -346,6 +367,71 @@ export function useRoutes({
                     transitStopLayerIdsRef.current.set(route.id, stopsLayerId);
                 }
             }
+
+            // Render alternative route geometries for expanded public transport routes
+            if (
+                route.transport_mode.value === 'public-transport' &&
+                expandedRoutes.has(route.id) &&
+                route.alternatives &&
+                route.alternatives.length > 0
+            ) {
+                route.alternatives.forEach((alt, altIndex) => {
+                    if (!alt.geometry || alt.geometry.length === 0) {
+                        return;
+                    }
+
+                    const altLayerId = `route-${route.id}-alt-${altIndex}`;
+                    const isSelectedAlt = selectedAlternativeIndex === altIndex;
+
+                    mapInstance.addSource(altLayerId, {
+                        type: 'geojson',
+                        data: {
+                            type: 'Feature',
+                            properties: {},
+                            geometry: {
+                                type: 'LineString',
+                                coordinates: alt.geometry,
+                            },
+                        },
+                    });
+
+                    mapInstance.addLayer(
+                        {
+                            id: altLayerId,
+                            type: 'line',
+                            source: altLayerId,
+                            layout: {
+                                'line-join': 'round',
+                                'line-cap': 'round',
+                            },
+                            paint: {
+                                'line-color': '#3498db',
+                                'line-width': isSelectedAlt ? 5 : 3,
+                                'line-opacity': isSelectedAlt ? 0.85 : 0.35,
+                                'line-dasharray': [2, 2],
+                            },
+                        },
+                        beforeLayerId,
+                    );
+
+                    mapInstance.on('click', altLayerId, (e) => {
+                        e.originalEvent.stopPropagation();
+                        if (onAlternativeClickRef.current) {
+                            onAlternativeClickRef.current(route.id, altIndex);
+                        }
+                    });
+
+                    mapInstance.on('mouseenter', altLayerId, () => {
+                        mapInstance.getCanvas().style.cursor = 'pointer';
+                    });
+
+                    mapInstance.on('mouseleave', altLayerId, () => {
+                        mapInstance.getCanvas().style.cursor = 'crosshair';
+                    });
+
+                    alternativeLayerIdsRef.current.set(altLayerId, altLayerId);
+                });
+            }
         });
 
         // Ensure proper layer ordering after adding all routes
@@ -357,6 +443,7 @@ export function useRoutes({
         tours,
         expandedRoutes,
         highlightedRouteId,
+        selectedAlternativeIndex,
     ]);
 
     return {

--- a/resources/js/types/route.ts
+++ b/resources/js/types/route.ts
@@ -57,6 +57,8 @@ export interface AlternativeRoute {
     distance: number;
     duration: number;
     num_transfers: number;
+    geometry: [number, number][] | null;
+    transit_details: TransitDetails | null;
 }
 
 export interface Route {

--- a/routes/web.php
+++ b/routes/web.php
@@ -80,6 +80,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/routes', [RouteController::class, 'index'])->name('routes.index');
     Route::post('/routes', [RouteController::class, 'store'])->name('routes.store');
     Route::get('/routes/{route}', [RouteController::class, 'show'])->name('routes.show');
+    Route::patch('/routes/{route}/alternative', [RouteController::class, 'updateAlternative'])->name('routes.alternative');
     Route::delete('/routes/{route}', [RouteController::class, 'destroy'])->name('routes.destroy');
 
     // Mapbox routes

--- a/tests/Feature/RouteControllerTest.php
+++ b/tests/Feature/RouteControllerTest.php
@@ -386,6 +386,137 @@ it('returns 404 when Google Maps finds no transit route', function () {
         ->assertJson(['error' => 'No public transport route found between the markers']);
 });
 
+// --- updateAlternative (PATCH /routes/{route}/alternative) ---
+
+it('can adopt an alternative public transport route', function () {
+    $alternatives = [
+        [
+            'distance' => 30000,
+            'duration' => 2400,
+            'geometry' => [[13.4, 52.5], [13.45, 52.52], [13.5, 52.55]],
+            'transit_details' => ['steps' => []],
+        ],
+        [
+            'distance' => 20000,
+            'duration' => 1800,
+            'geometry' => [[13.4, 52.5], [13.47, 52.53]],
+            'transit_details' => ['steps' => []],
+        ],
+    ];
+
+    $route = Route::factory()->create([
+        'trip_id' => $this->trip->id,
+        'start_marker_id' => $this->startMarker->id,
+        'end_marker_id' => $this->endMarker->id,
+        'transport_mode' => 'public-transport',
+        'alternatives' => $alternatives,
+    ]);
+
+    $response = $this->patchJson("/routes/{$route->id}/alternative", [
+        'alternative_index' => 1,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonStructure(['id', 'distance', 'duration', 'geometry', 'transit_details'])
+        ->assertJsonPath('distance.meters', 20000)
+        ->assertJsonPath('duration.seconds', 1800);
+
+    $this->assertDatabaseHas('routes', [
+        'id' => $route->id,
+        'distance' => 20000,
+        'duration' => 1800,
+    ]);
+
+    // alternatives should be cleared after adoption
+    expect(Route::find($route->id)->alternatives)->toBeNull();
+});
+
+it('returns 422 when adopting alternative for non-public-transport route', function () {
+    $route = Route::factory()->create([
+        'trip_id' => $this->trip->id,
+        'start_marker_id' => $this->startMarker->id,
+        'end_marker_id' => $this->endMarker->id,
+        'transport_mode' => 'driving-car',
+        'alternatives' => null,
+    ]);
+
+    $response = $this->patchJson("/routes/{$route->id}/alternative", [
+        'alternative_index' => 0,
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJson(['error' => 'Alternative selection is only available for public transport routes']);
+});
+
+it('returns 422 when alternative index is out of range', function () {
+    $route = Route::factory()->create([
+        'trip_id' => $this->trip->id,
+        'start_marker_id' => $this->startMarker->id,
+        'end_marker_id' => $this->endMarker->id,
+        'transport_mode' => 'public-transport',
+        'alternatives' => [
+            [
+                'distance' => 30000,
+                'duration' => 2400,
+                'geometry' => [[13.4, 52.5]],
+                'transit_details' => ['steps' => []],
+            ],
+        ],
+    ]);
+
+    $response = $this->patchJson("/routes/{$route->id}/alternative", [
+        'alternative_index' => 5,
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJson(['error' => 'Alternative index out of range']);
+});
+
+it('validates alternative_index is required and is a non-negative integer', function () {
+    $route = Route::factory()->create([
+        'trip_id' => $this->trip->id,
+        'start_marker_id' => $this->startMarker->id,
+        'end_marker_id' => $this->endMarker->id,
+        'transport_mode' => 'public-transport',
+    ]);
+
+    $this->patchJson("/routes/{$route->id}/alternative", [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['alternative_index']);
+
+    $this->patchJson("/routes/{$route->id}/alternative", ['alternative_index' => -1])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['alternative_index']);
+});
+
+it('cannot adopt an alternative on another users route', function () {
+    $otherUser = User::factory()->create();
+    $otherTrip = Trip::factory()->create(['user_id' => $otherUser->id]);
+    $otherStart = Marker::factory()->create(['trip_id' => $otherTrip->id]);
+    $otherEnd = Marker::factory()->create(['trip_id' => $otherTrip->id]);
+
+    $route = Route::factory()->create([
+        'trip_id' => $otherTrip->id,
+        'start_marker_id' => $otherStart->id,
+        'end_marker_id' => $otherEnd->id,
+        'transport_mode' => 'public-transport',
+        'alternatives' => [
+            [
+                'distance' => 10000,
+                'duration' => 900,
+                'geometry' => [[13.4, 52.5]],
+                'transit_details' => ['steps' => []],
+            ],
+        ],
+    ]);
+
+    $response = $this->patchJson("/routes/{$route->id}/alternative", [
+        'alternative_index' => 0,
+    ]);
+
+    $response->assertForbidden();
+});
+
 it('can create a route with tour_id', function () {
     // Create a tour for this trip
     $tour = \App\Models\Tour::factory()->create(['trip_id' => $this->trip->id]);


### PR DESCRIPTION
## Summary

- Enriches the Google Routes API response extraction to store `geometry` and `transit_details` on every alternative route
- Adds `PATCH /routes/{route}/alternative` endpoint (`updateAlternative`) to swap the primary route with a chosen alternative
- Renders alternative routes on the map as semi-transparent dashed lines with hover highlight and click-to-select behaviour
- Adds an interactive `AlternativeRoutesList` UI with radio-style selection and an "Adopt this route" button wired through all layout components (desktop + mobile)
- Adds feature tests covering the happy path, transport mode guard, index-out-of-range, validation, and authorization

## How to test

1. Create a public transport route between two markers — the API should return alternatives
2. Open the Route panel and expand the route — you should see the alternatives listed
3. Click an alternative in the list or on the map line — it becomes selected (highlighted)
4. Click "Adopt this route" — the route is updated and alternatives are cleared

## Breaking changes / migrations

None — the `alternatives` column already exists.

Closes #315