### PR TITLE
feat(map): add manual waypoints to route creation

### DIFF
--- a/app/Http/Controllers/RouteController.php
+++ b/app/Http/Controllers/RouteController.php
@@ -57,6 +57,9 @@ class RouteController extends Controller
         try {
             $transportMode = TransportMode::from($validated['transport_mode']);
             $waypoints = $validated['waypoints'] ?? [];
+            if ($transportMode === TransportMode::PublicTransport) {
+                $waypoints = [];
+            }
             $routeData = $this->routingService->calculateRoute($startMarker, $endMarker, $transportMode, $waypoints);
 
             $route = Route::create([

--- a/app/Http/Controllers/RouteController.php
+++ b/app/Http/Controllers/RouteController.php
@@ -56,7 +56,8 @@ class RouteController extends Controller
 
         try {
             $transportMode = TransportMode::from($validated['transport_mode']);
-            $routeData = $this->routingService->calculateRoute($startMarker, $endMarker, $transportMode);
+            $waypoints = $validated['waypoints'] ?? [];
+            $routeData = $this->routingService->calculateRoute($startMarker, $endMarker, $transportMode, $waypoints);
 
             $route = Route::create([
                 'trip_id' => $trip->id,
@@ -67,6 +68,7 @@ class RouteController extends Controller
                 'distance' => $routeData['distance'],
                 'duration' => $routeData['duration'],
                 'geometry' => $routeData['geometry'],
+                'waypoints' => ! empty($waypoints) ? $waypoints : null,
                 'transit_details' => $routeData['transit_details'] ?? null,
                 'alternatives' => $routeData['alternatives'] ?? null,
                 'warning' => $routeData['warning'] ?? null,

--- a/app/Http/Requests/StoreRouteRequest.php
+++ b/app/Http/Requests/StoreRouteRequest.php
@@ -27,6 +27,9 @@ class StoreRouteRequest extends FormRequest
             'start_marker_id' => 'required|uuid|exists:markers,id',
             'end_marker_id' => 'required|uuid|exists:markers,id|different:start_marker_id',
             'transport_mode' => 'required|string|in:driving-car,cycling-regular,foot-walking,public-transport',
+            'waypoints' => 'nullable|array|max:20',
+            'waypoints.*.lat' => 'required_with:waypoints|numeric|between:-90,90',
+            'waypoints.*.lng' => 'required_with:waypoints|numeric|between:-180,180',
         ];
     }
 }

--- a/app/Http/Resources/RouteResource.php
+++ b/app/Http/Resources/RouteResource.php
@@ -33,6 +33,7 @@ class RouteResource extends JsonResource
                 'minutes' => $this->duration_in_minutes,
             ],
             'geometry' => $this->geometry,
+            'waypoints' => $this->waypoints,
             'transit_details' => $this->transit_details,
             'alternatives' => $this->alternatives,
             'warning' => $this->warning,

--- a/app/Models/Route.php
+++ b/app/Models/Route.php
@@ -21,6 +21,7 @@ class Route extends Model
         'distance',
         'duration',
         'geometry',
+        'waypoints',
         'transit_details',
         'alternatives',
         'warning',
@@ -31,6 +32,7 @@ class Route extends Model
         return [
             'transport_mode' => TransportMode::class,
             'geometry' => 'array',
+            'waypoints' => 'array',
             'transit_details' => 'array',
             'alternatives' => 'array',
             'distance' => 'integer',

--- a/app/Services/RoutingService.php
+++ b/app/Services/RoutingService.php
@@ -22,6 +22,7 @@ class RoutingService
     /**
      * Calculate route between two markers using Mapbox Directions API.
      *
+     * @param  array<int, array{lat: float, lng: float}>  $waypoints
      * @return array{distance: int, duration: int, geometry: array, warning: string|null}
      *
      * @throws RouteNotFoundException
@@ -31,7 +32,8 @@ class RoutingService
     public function calculateRoute(
         Marker $startMarker,
         Marker $endMarker,
-        TransportMode $transportMode = TransportMode::DrivingCar
+        TransportMode $transportMode = TransportMode::DrivingCar,
+        array $waypoints = []
     ): array {
         // Use Google Transit API for public transport
         if ($transportMode === TransportMode::PublicTransport) {
@@ -39,7 +41,7 @@ class RoutingService
         }
 
         // Use Mapbox for other transport modes
-        return $this->calculateMapboxRoute($startMarker, $endMarker, $transportMode);
+        return $this->calculateMapboxRoute($startMarker, $endMarker, $transportMode, $waypoints);
     }
 
     /**
@@ -146,6 +148,7 @@ class RoutingService
     /**
      * Calculate route using Mapbox Directions API.
      *
+     * @param  array<int, array{lat: float, lng: float}>  $waypoints
      * @return array{distance: int, duration: int, geometry: array, transit_details: null, alternatives: null, warning: string|null}
      *
      * @throws RouteNotFoundException
@@ -155,7 +158,8 @@ class RoutingService
     private function calculateMapboxRoute(
         Marker $startMarker,
         Marker $endMarker,
-        TransportMode $transportMode
+        TransportMode $transportMode,
+        array $waypoints = []
     ): array {
         // Check quota before making request
         $this->limiter->checkQuota();
@@ -168,13 +172,18 @@ class RoutingService
 
         $profile = $this->getMapboxProfile($transportMode);
 
-        $coordinates = sprintf(
-            '%s,%s;%s,%s',
-            $startMarker->longitude,
-            $startMarker->latitude,
-            $endMarker->longitude,
-            $endMarker->latitude
-        );
+        // Build coordinate string: start ; waypoints... ; end
+        $coordinateParts = [
+            sprintf('%s,%s', $startMarker->longitude, $startMarker->latitude),
+        ];
+
+        foreach ($waypoints as $waypoint) {
+            $coordinateParts[] = sprintf('%s,%s', $waypoint['lng'], $waypoint['lat']);
+        }
+
+        $coordinateParts[] = sprintf('%s,%s', $endMarker->longitude, $endMarker->latitude);
+
+        $coordinates = implode(';', $coordinateParts);
 
         $url = sprintf(
             '%s/directions/v5/mapbox/%s/%s',

--- a/database/migrations/2026_03_11_164358_add_waypoints_to_routes_table.php
+++ b/database/migrations/2026_03_11_164358_add_waypoints_to_routes_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('routes', function (Blueprint $table) {
+            $table->json('waypoints')->nullable()->after('geometry');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('routes', function (Blueprint $table) {
+            $table->dropColumn('waypoints');
+        });
+    }
+};

--- a/resources/js/components/route-panel.tsx
+++ b/resources/js/components/route-panel.tsx
@@ -381,9 +381,14 @@ export default function RoutePanel({
                         <Label htmlFor="transport-mode">Transport Mode</Label>
                         <Select
                             value={transportMode}
-                            onValueChange={(value) =>
-                                setTransportMode(value as TransportMode)
-                            }
+                            onValueChange={(value) => {
+                                const newMode = value as TransportMode;
+                                setTransportMode(newMode);
+                                if (newMode === 'public-transport') {
+                                    onClearWaypoints?.();
+                                    onWaypointModeChange?.(false);
+                                }
+                            }}
                         >
                             <SelectTrigger id="transport-mode">
                                 <SelectValue />

--- a/resources/js/components/route-panel.tsx
+++ b/resources/js/components/route-panel.tsx
@@ -24,7 +24,7 @@ import {
 import { formatDuration } from '@/lib/route-formatting';
 import { getTransportColor, getTransportIcon } from '@/lib/transport-utils';
 import { MarkerApiData } from '@/types/marker';
-import { Route, TransportMode } from '@/types/route';
+import { Route, TransportMode, Waypoint } from '@/types/route';
 import { Tour } from '@/types/tour';
 import axios from 'axios';
 import {
@@ -33,9 +33,11 @@ import {
     Car,
     ChevronDown,
     ChevronUp,
+    MapPin,
     PersonStanding,
     Train,
     Trash2,
+    X,
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
@@ -59,6 +61,11 @@ interface RoutePanelProps {
         routeId: number | null,
         index: number | null,
     ) => void;
+    isWaypointMode?: boolean;
+    onWaypointModeChange?: (value: boolean) => void;
+    pendingWaypoints?: Waypoint[];
+    onRemoveWaypoint?: (index: number) => void;
+    onClearWaypoints?: () => void;
 }
 
 export default function RoutePanel({
@@ -77,6 +84,11 @@ export default function RoutePanel({
     onTourUpdate,
     selectedAlternativeIndex = null,
     onSelectedAlternativeIndexChange,
+    isWaypointMode = false,
+    onWaypointModeChange,
+    pendingWaypoints = [],
+    onRemoveWaypoint,
+    onClearWaypoints,
 }: RoutePanelProps) {
     const [startMarkerId, setStartMarkerId] =
         useState<string>(initialStartMarkerId);
@@ -123,6 +135,10 @@ export default function RoutePanel({
                     start_marker_id: startMarkerId,
                     end_marker_id: endMarkerId,
                     transport_mode: transportMode,
+                    waypoints:
+                        pendingWaypoints.length > 0
+                            ? pendingWaypoints
+                            : undefined,
                 },
                 {
                     headers: {
@@ -139,6 +155,8 @@ export default function RoutePanel({
             setStartMarkerId('');
             setEndMarkerId('');
             setTransportMode('driving-car');
+            onClearWaypoints?.();
+            onWaypointModeChange?.(false);
         } catch (err) {
             console.error('Failed to create route:', err);
             console.error('Request payload:', {
@@ -398,6 +416,78 @@ export default function RoutePanel({
                             </SelectContent>
                         </Select>
                     </div>
+
+                    {/* Waypoint mode toggle - not available for public transport */}
+                    {onWaypointModeChange &&
+                        transportMode !== 'public-transport' && (
+                            <div className="space-y-2">
+                                <Button
+                                    type="button"
+                                    variant={
+                                        isWaypointMode ? 'default' : 'outline'
+                                    }
+                                    size="sm"
+                                    onClick={() =>
+                                        onWaypointModeChange(!isWaypointMode)
+                                    }
+                                    className="w-full"
+                                    data-testid="waypoint-mode-toggle"
+                                >
+                                    <MapPin className="mr-2 h-4 w-4" />
+                                    {isWaypointMode
+                                        ? 'Click map to add waypoints (active)'
+                                        : 'Add waypoints'}
+                                </Button>
+
+                                {pendingWaypoints.length > 0 && (
+                                    <div className="space-y-1 rounded-md border p-2">
+                                        <div className="flex items-center justify-between">
+                                            <span className="text-xs font-medium text-muted-foreground">
+                                                Waypoints (
+                                                {pendingWaypoints.length}
+                                                /20)
+                                            </span>
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="sm"
+                                                onClick={onClearWaypoints}
+                                                className="h-5 px-2 text-xs text-muted-foreground hover:text-destructive"
+                                                data-testid="clear-waypoints"
+                                            >
+                                                Clear all
+                                            </Button>
+                                        </div>
+                                        {pendingWaypoints.map((wp, index) => (
+                                            <div
+                                                key={index}
+                                                className="flex items-center justify-between rounded bg-muted/50 px-2 py-1 text-xs"
+                                            >
+                                                <span className="font-mono text-muted-foreground">
+                                                    {index + 1}.{' '}
+                                                    {wp.lat.toFixed(5)},{' '}
+                                                    {wp.lng.toFixed(5)}
+                                                </span>
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    onClick={() =>
+                                                        onRemoveWaypoint?.(
+                                                            index,
+                                                        )
+                                                    }
+                                                    className="h-4 w-4 text-muted-foreground hover:text-destructive"
+                                                    data-testid={`remove-waypoint-${index}`}
+                                                >
+                                                    <X className="h-3 w-3" />
+                                                </Button>
+                                            </div>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+                        )}
 
                     {error && (
                         <div className="rounded-md bg-red-50 p-3 text-sm text-red-800 dark:bg-red-900/20 dark:text-red-400">

--- a/resources/js/components/travel-map/desktop-panels.tsx
+++ b/resources/js/components/travel-map/desktop-panels.tsx
@@ -7,7 +7,7 @@ import { TabButton } from '@/components/tab-button';
 import TourPanel from '@/components/tour-panel';
 import { PanelType } from '@/hooks/use-panels';
 import { MarkerData, MarkerType } from '@/types/marker';
-import { Route } from '@/types/route';
+import { Route, Waypoint } from '@/types/route';
 import { Tour } from '@/types/tour';
 import { Trip } from '@/types/trip';
 import { Bot, List, Map as MapIcon, Route as RouteIcon } from 'lucide-react';
@@ -72,6 +72,13 @@ interface DesktopPanelsProps {
         index: number | null,
     ) => void;
 
+    // Waypoint mode
+    isWaypointMode: boolean;
+    setIsWaypointMode: (value: boolean) => void;
+    pendingWaypoints: Waypoint[];
+    onRemoveWaypoint: (index: number) => void;
+    onClearWaypoints: () => void;
+
     // Available marker selection (for tours)
     selectedAvailableMarkerId: string | null;
     handleSelectAvailableMarker: (markerId: string | null) => void;
@@ -129,6 +136,11 @@ export function DesktopPanels({
     mapBounds,
     selectedAlternativeIndex,
     onSelectedAlternativeIndexChange,
+    isWaypointMode,
+    setIsWaypointMode,
+    pendingWaypoints,
+    onRemoveWaypoint,
+    onClearWaypoints,
 }: DesktopPanelsProps) {
     const { t } = useTranslation();
 
@@ -262,6 +274,11 @@ export function DesktopPanels({
                         onSelectedAlternativeIndexChange={
                             onSelectedAlternativeIndexChange
                         }
+                        isWaypointMode={isWaypointMode}
+                        onWaypointModeChange={setIsWaypointMode}
+                        pendingWaypoints={pendingWaypoints}
+                        onRemoveWaypoint={onRemoveWaypoint}
+                        onClearWaypoints={onClearWaypoints}
                     />
                 </FloatingPanel>
             )}

--- a/resources/js/components/travel-map/index.tsx
+++ b/resources/js/components/travel-map/index.tsx
@@ -21,6 +21,7 @@ import { useSearchResults } from '@/hooks/use-search-results';
 import { useTourLines } from '@/hooks/use-tour-lines';
 import { useTourMarkers } from '@/hooks/use-tour-markers';
 import { useTripNotes } from '@/hooks/use-trip-notes';
+import { useWaypointMode } from '@/hooks/use-waypoint-mode';
 import { getBoundingBoxFromTrip } from '@/lib/map-utils';
 import { type TripOwner } from '@/types';
 import { Route } from '@/types/route';
@@ -132,6 +133,17 @@ export default function TravelMap({
     const { isSearchMode, setIsSearchMode, isSearchModeRef } = useSearchMode({
         mapInstance,
     });
+
+    // Waypoint mode management
+    const {
+        isWaypointMode,
+        setIsWaypointMode,
+        isWaypointModeRef,
+        pendingWaypoints,
+        addWaypoint,
+        removeWaypoint,
+        clearWaypoints,
+    } = useWaypointMode({ mapInstance });
 
     // Search radius management
     const { searchRadius, setSearchRadius } = useSearchRadius();
@@ -313,8 +325,10 @@ export default function TravelMap({
     useMapInteractions({
         mapInstance,
         isSearchModeRef,
+        isWaypointModeRef,
         onMarkerCreated: addMarker,
         onMarkerSelected: setSelectedMarkerId,
+        onWaypointAdded: addWaypoint,
     });
 
     // Auto-open markers panel when a marker is selected, except when managing a tour in the open Tour panel
@@ -380,6 +394,11 @@ export default function TravelMap({
                 ? selectedAlternativeIndex
                 : null,
         onSelectedAlternativeIndexChange: handleSelectedAlternativeIndexChange,
+        isWaypointMode,
+        setIsWaypointMode,
+        pendingWaypoints,
+        onRemoveWaypoint: removeWaypoint,
+        onClearWaypoints: clearWaypoints,
     };
 
     return (

--- a/resources/js/components/travel-map/mobile-panels.tsx
+++ b/resources/js/components/travel-map/mobile-panels.tsx
@@ -7,7 +7,7 @@ import RoutePanel from '@/components/route-panel';
 import TourPanel from '@/components/tour-panel';
 import { PanelType } from '@/hooks/use-panels';
 import { MarkerData, MarkerType } from '@/types/marker';
-import { Route } from '@/types/route';
+import { Route, Waypoint } from '@/types/route';
 import { Tour } from '@/types/tour';
 import { Trip } from '@/types/trip';
 import { AnimatePresence } from 'framer-motion';
@@ -72,6 +72,13 @@ interface MobilePanelsProps {
         index: number | null,
     ) => void;
 
+    // Waypoint mode
+    isWaypointMode: boolean;
+    setIsWaypointMode: (value: boolean) => void;
+    pendingWaypoints: Waypoint[];
+    onRemoveWaypoint: (index: number) => void;
+    onClearWaypoints: () => void;
+
     // Available marker selection (for tours)
     selectedAvailableMarkerId: string | null;
     handleSelectAvailableMarker: (markerId: string | null) => void;
@@ -129,6 +136,11 @@ export function MobilePanels({
     mapBounds,
     selectedAlternativeIndex,
     onSelectedAlternativeIndexChange,
+    isWaypointMode,
+    setIsWaypointMode,
+    pendingWaypoints,
+    onRemoveWaypoint,
+    onClearWaypoints,
 }: MobilePanelsProps) {
     const { t } = useTranslation();
 
@@ -237,6 +249,11 @@ export function MobilePanels({
                             onSelectedAlternativeIndexChange={
                                 onSelectedAlternativeIndexChange
                             }
+                            isWaypointMode={isWaypointMode}
+                            onWaypointModeChange={setIsWaypointMode}
+                            pendingWaypoints={pendingWaypoints}
+                            onRemoveWaypoint={onRemoveWaypoint}
+                            onClearWaypoints={onClearWaypoints}
                         />
                     </DraggableSheet>
                 )}

--- a/resources/js/hooks/use-map-interactions.ts
+++ b/resources/js/hooks/use-map-interactions.ts
@@ -3,6 +3,7 @@ import {
     getMarkerTypeFromMapboxClass,
 } from '@/lib/marker-utils';
 import { MarkerData, MarkerType } from '@/types/marker';
+import { Waypoint } from '@/types/route';
 import mapboxgl, {
     FeatureSelector,
     GeoJSONFeature,
@@ -14,17 +15,26 @@ import { v4 as uuidv4 } from 'uuid';
 interface UseMapInteractionsOptions {
     mapInstance: mapboxgl.Map | null;
     isSearchModeRef: React.MutableRefObject<boolean>;
+    isWaypointModeRef?: React.MutableRefObject<boolean>;
     onMarkerCreated: (marker: MarkerData) => void;
     onMarkerSelected: (markerId: string) => void;
+    onWaypointAdded?: (waypoint: Waypoint) => void;
 }
 
 export function useMapInteractions({
     mapInstance,
     isSearchModeRef,
+    isWaypointModeRef,
     onMarkerCreated,
     onMarkerSelected,
+    onWaypointAdded,
 }: UseMapInteractionsOptions) {
     const registeredInteractionIdsRef = useRef<Set<string>>(new Set());
+    const onWaypointAddedRef = useRef(onWaypointAdded);
+
+    useEffect(() => {
+        onWaypointAddedRef.current = onWaypointAdded;
+    }, [onWaypointAdded]);
 
     useEffect(() => {
         if (!mapInstance) return;
@@ -378,6 +388,17 @@ export function useMapInteractions({
                 return f.layer?.id?.startsWith('tour-line-');
             });
 
+            // In waypoint mode, intercept clicks to add waypoints instead of markers
+            if (isWaypointModeRef?.current) {
+                if (!hasInteractiveFeature && !hasTourLineLayer) {
+                    onWaypointAddedRef.current?.({
+                        lat: e.lngLat.lat,
+                        lng: e.lngLat.lng,
+                    });
+                }
+                return;
+            }
+
             if (hasInteractiveFeature || hasRouteLayer || hasTourLineLayer) {
                 console.log(
                     'handleMapClick: Interactive feature, route layer, or tour line clicked, ignoring',
@@ -435,5 +456,11 @@ export function useMapInteractions({
         return () => {
             mapInstance.off('click', handleMapClick);
         };
-    }, [mapInstance, isSearchModeRef, onMarkerCreated, onMarkerSelected]);
+    }, [
+        mapInstance,
+        isSearchModeRef,
+        isWaypointModeRef,
+        onMarkerCreated,
+        onMarkerSelected,
+    ]);
 }

--- a/resources/js/hooks/use-map-interactions.ts
+++ b/resources/js/hooks/use-map-interactions.ts
@@ -390,7 +390,11 @@ export function useMapInteractions({
 
             // In waypoint mode, intercept clicks to add waypoints instead of markers
             if (isWaypointModeRef?.current) {
-                if (!hasInteractiveFeature && !hasTourLineLayer) {
+                if (
+                    !hasInteractiveFeature &&
+                    !hasRouteLayer &&
+                    !hasTourLineLayer
+                ) {
                     onWaypointAddedRef.current?.({
                         lat: e.lngLat.lat,
                         lng: e.lngLat.lng,

--- a/resources/js/hooks/use-routes.ts
+++ b/resources/js/hooks/use-routes.ts
@@ -2,7 +2,7 @@ import {
     ensureVectorLayerOrder,
     getFirstSymbolLayerId,
 } from '@/lib/map-layers';
-import { Route } from '@/types/route';
+import { Route, Waypoint } from '@/types/route';
 import { Tour } from '@/types/tour';
 import axios from 'axios';
 import mapboxgl from 'mapbox-gl';
@@ -34,6 +34,7 @@ export function useRoutes({
     const [routes, setRoutes] = useState<Route[]>([]);
     const routeLayerIdsRef = useRef<Map<number, string>>(new Map());
     const transitStopLayerIdsRef = useRef<Map<number, string>>(new Map());
+    const waypointLayerIdsRef = useRef<Map<number, string>>(new Map());
     const alternativeLayerIdsRef = useRef<Map<string, string>>(new Map());
     const onRouteClickRef = useRef(onRouteClick);
     const onAlternativeClickRef = useRef(onAlternativeClick);
@@ -96,6 +97,17 @@ export function useRoutes({
             }
         });
         transitStopLayerIdsRef.current.clear();
+
+        // Clear existing waypoint layers
+        waypointLayerIdsRef.current.forEach((layerId) => {
+            if (mapInstance.getLayer(layerId)) {
+                mapInstance.removeLayer(layerId);
+            }
+            if (mapInstance.getSource(layerId)) {
+                mapInstance.removeSource(layerId);
+            }
+        });
+        waypointLayerIdsRef.current.clear();
 
         // Clear existing alternative route layers
         alternativeLayerIdsRef.current.forEach((layerId) => {
@@ -366,6 +378,49 @@ export function useRoutes({
 
                     transitStopLayerIdsRef.current.set(route.id, stopsLayerId);
                 }
+            }
+
+            // Render saved waypoints as small circles on non-public-transport routes
+            if (
+                route.transport_mode.value !== 'public-transport' &&
+                route.waypoints &&
+                route.waypoints.length > 0
+            ) {
+                const waypointsLayerId = `route-${route.id}-waypoints`;
+
+                mapInstance.addSource(waypointsLayerId, {
+                    type: 'geojson',
+                    data: {
+                        type: 'FeatureCollection',
+                        features: (route.waypoints as Waypoint[]).map((wp) => ({
+                            type: 'Feature' as const,
+                            properties: {},
+                            geometry: {
+                                type: 'Point' as const,
+                                coordinates: [wp.lng, wp.lat],
+                            },
+                        })),
+                    },
+                });
+
+                mapInstance.addLayer(
+                    {
+                        id: waypointsLayerId,
+                        type: 'circle',
+                        source: waypointsLayerId,
+                        paint: {
+                            'circle-radius': 6,
+                            'circle-color': color,
+                            'circle-opacity': isHighlighted ? 0.95 : 0.8,
+                            'circle-stroke-width': 2,
+                            'circle-stroke-color': '#ffffff',
+                            'circle-stroke-opacity': 0.9,
+                        },
+                    },
+                    beforeLayerId,
+                );
+
+                waypointLayerIdsRef.current.set(route.id, waypointsLayerId);
             }
 
             // Render alternative route geometries for expanded public transport routes

--- a/resources/js/hooks/use-waypoint-mode.ts
+++ b/resources/js/hooks/use-waypoint-mode.ts
@@ -1,0 +1,51 @@
+import { Waypoint } from '@/types/route';
+import mapboxgl from 'mapbox-gl';
+import { useEffect, useRef, useState } from 'react';
+
+interface UseWaypointModeOptions {
+    mapInstance: mapboxgl.Map | null;
+}
+
+export function useWaypointMode({ mapInstance }: UseWaypointModeOptions) {
+    const [isWaypointMode, setIsWaypointMode] = useState(false);
+    const [pendingWaypoints, setPendingWaypoints] = useState<Waypoint[]>([]);
+    const isWaypointModeRef = useRef(false);
+
+    useEffect(() => {
+        if (!mapInstance) return;
+        isWaypointModeRef.current = isWaypointMode;
+
+        if (isWaypointMode) {
+            mapInstance.getCanvas().style.cursor = 'crosshair';
+        } else {
+            mapInstance.getCanvas().style.cursor = 'crosshair';
+        }
+    }, [isWaypointMode, mapInstance]);
+
+    const addWaypoint = (waypoint: Waypoint) => {
+        setPendingWaypoints((prev) => [...prev, waypoint]);
+    };
+
+    const removeWaypoint = (index: number) => {
+        setPendingWaypoints((prev) => prev.filter((_, i) => i !== index));
+    };
+
+    const clearWaypoints = () => {
+        setPendingWaypoints([]);
+    };
+
+    const exitWaypointMode = () => {
+        setIsWaypointMode(false);
+    };
+
+    return {
+        isWaypointMode,
+        setIsWaypointMode,
+        isWaypointModeRef,
+        pendingWaypoints,
+        addWaypoint,
+        removeWaypoint,
+        clearWaypoints,
+        exitWaypointMode,
+    } as const;
+}

--- a/resources/js/hooks/use-waypoint-mode.ts
+++ b/resources/js/hooks/use-waypoint-mode.ts
@@ -18,7 +18,7 @@ export function useWaypointMode({ mapInstance }: UseWaypointModeOptions) {
         if (isWaypointMode) {
             mapInstance.getCanvas().style.cursor = 'crosshair';
         } else {
-            mapInstance.getCanvas().style.cursor = 'crosshair';
+            mapInstance.getCanvas().style.cursor = '';
         }
     }, [isWaypointMode, mapInstance]);
 

--- a/resources/js/types/route.ts
+++ b/resources/js/types/route.ts
@@ -4,6 +4,11 @@ export type TransportMode =
     | 'foot-walking'
     | 'public-transport';
 
+export interface Waypoint {
+    lat: number;
+    lng: number;
+}
+
 export interface RouteMarker {
     id: string;
     name: string;
@@ -80,6 +85,7 @@ export interface Route {
         minutes: number;
     };
     geometry: [number, number][]; // GeoJSON coordinates [lng, lat]
+    waypoints: Waypoint[] | null;
     transit_details: TransitDetails | null;
     alternatives: AlternativeRoute[] | null;
     warning: string | null;

--- a/tests/Feature/RouteControllerTest.php
+++ b/tests/Feature/RouteControllerTest.php
@@ -561,3 +561,124 @@ it('can create a route with tour_id', function () {
         'end_marker_id' => $this->endMarker->id,
     ]);
 });
+
+it('can create a route with waypoints and stores them in the database', function () {
+    config(['services.mapbox.access_token' => 'test-token']);
+
+    Http::fake([
+        'api.mapbox.com/*' => Http::response([
+            'routes' => [
+                [
+                    'distance' => 15000,
+                    'duration' => 900,
+                    'geometry' => [
+                        'coordinates' => [
+                            [$this->startMarker->longitude, $this->startMarker->latitude],
+                            [1.5, 49.0],
+                            [$this->endMarker->longitude, $this->endMarker->latitude],
+                        ],
+                    ],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $waypoints = [
+        ['lat' => 49.0, 'lng' => 1.5],
+    ];
+
+    $response = $this->postJson('/routes', [
+        'trip_id' => $this->trip->id,
+        'start_marker_id' => $this->startMarker->id,
+        'end_marker_id' => $this->endMarker->id,
+        'transport_mode' => 'foot-walking',
+        'waypoints' => $waypoints,
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonPath('waypoints.0.lat', 49)
+        ->assertJsonPath('waypoints.0.lng', 1.5);
+
+    $this->assertDatabaseHas('routes', [
+        'trip_id' => $this->trip->id,
+        'start_marker_id' => $this->startMarker->id,
+        'end_marker_id' => $this->endMarker->id,
+        'transport_mode' => 'foot-walking',
+    ]);
+});
+
+it('creates a route without waypoints when not provided', function () {
+    config(['services.mapbox.access_token' => 'test-token']);
+
+    Http::fake([
+        'api.mapbox.com/*' => Http::response([
+            'routes' => [
+                [
+                    'distance' => 10000,
+                    'duration' => 600,
+                    'geometry' => [
+                        'coordinates' => [
+                            [$this->startMarker->longitude, $this->startMarker->latitude],
+                            [$this->endMarker->longitude, $this->endMarker->latitude],
+                        ],
+                    ],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $response = $this->postJson('/routes', [
+        'trip_id' => $this->trip->id,
+        'start_marker_id' => $this->startMarker->id,
+        'end_marker_id' => $this->endMarker->id,
+        'transport_mode' => 'driving-car',
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonPath('waypoints', null);
+});
+
+it('rejects waypoints with invalid latitude', function () {
+    $response = $this->postJson('/routes', [
+        'trip_id' => $this->trip->id,
+        'start_marker_id' => $this->startMarker->id,
+        'end_marker_id' => $this->endMarker->id,
+        'transport_mode' => 'foot-walking',
+        'waypoints' => [
+            ['lat' => 999.0, 'lng' => 1.5],
+        ],
+    ]);
+
+    $response->assertUnprocessable()
+        ->assertJsonValidationErrors(['waypoints.0.lat']);
+});
+
+it('rejects waypoints with invalid longitude', function () {
+    $response = $this->postJson('/routes', [
+        'trip_id' => $this->trip->id,
+        'start_marker_id' => $this->startMarker->id,
+        'end_marker_id' => $this->endMarker->id,
+        'transport_mode' => 'foot-walking',
+        'waypoints' => [
+            ['lat' => 49.0, 'lng' => 999.0],
+        ],
+    ]);
+
+    $response->assertUnprocessable()
+        ->assertJsonValidationErrors(['waypoints.0.lng']);
+});
+
+it('rejects more than 20 waypoints', function () {
+    $tooManyWaypoints = array_fill(0, 21, ['lat' => 49.0, 'lng' => 1.5]);
+
+    $response = $this->postJson('/routes', [
+        'trip_id' => $this->trip->id,
+        'start_marker_id' => $this->startMarker->id,
+        'end_marker_id' => $this->endMarker->id,
+        'transport_mode' => 'foot-walking',
+        'waypoints' => $tooManyWaypoints,
+    ]);
+
+    $response->assertUnprocessable()
+        ->assertJsonValidationErrors(['waypoints']);
+});

--- a/tests/Feature/RouteControllerTest.php
+++ b/tests/Feature/RouteControllerTest.php
@@ -604,6 +604,7 @@ it('can create a route with waypoints and stores them in the database', function
         'start_marker_id' => $this->startMarker->id,
         'end_marker_id' => $this->endMarker->id,
         'transport_mode' => 'foot-walking',
+        'waypoints' => json_encode($waypoints),
     ]);
 });
 

--- a/tests/Feature/RoutingServiceWaypointTest.php
+++ b/tests/Feature/RoutingServiceWaypointTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use App\Enums\TransportMode;
+use App\Models\Marker;
+use App\Services\RoutingService;
+use Illuminate\Support\Facades\Http;
+
+uses()->group('routing');
+
+beforeEach(function () {
+    config(['services.mapbox.access_token' => 'test-token']);
+
+    $this->startMarker = new Marker([
+        'latitude' => 48.8566,
+        'longitude' => 2.3522,
+    ]);
+
+    $this->endMarker = new Marker([
+        'latitude' => 51.5074,
+        'longitude' => -0.1278,
+    ]);
+});
+
+it('builds coordinate string without waypoints', function () {
+    $capturedUrl = null;
+
+    Http::fake(function ($request) use (&$capturedUrl) {
+        $capturedUrl = $request->url();
+
+        return Http::response([
+            'routes' => [[
+                'distance' => 10000,
+                'duration' => 600,
+                'geometry' => ['coordinates' => [[2.3522, 48.8566], [-0.1278, 51.5074]]],
+            ]],
+        ], 200);
+    });
+
+    $service = new RoutingService;
+    $service->calculateRoute($this->startMarker, $this->endMarker, TransportMode::FootWalking);
+
+    expect($capturedUrl)->toContain('2.3522,48.8566;-0.1278,51.5074');
+});
+
+it('builds coordinate string with a single waypoint', function () {
+    $capturedUrl = null;
+
+    Http::fake(function ($request) use (&$capturedUrl) {
+        $capturedUrl = $request->url();
+
+        return Http::response([
+            'routes' => [[
+                'distance' => 12000,
+                'duration' => 700,
+                'geometry' => ['coordinates' => [[2.3522, 48.8566], [1.0, 50.0], [-0.1278, 51.5074]]],
+            ]],
+        ], 200);
+    });
+
+    $service = new RoutingService;
+    $service->calculateRoute(
+        $this->startMarker,
+        $this->endMarker,
+        TransportMode::FootWalking,
+        [['lat' => 50.0, 'lng' => 1.0]]
+    );
+
+    expect($capturedUrl)->toContain('2.3522,48.8566;1,50;-0.1278,51.5074');
+});
+
+it('builds coordinate string with multiple waypoints in correct order', function () {
+    $capturedUrl = null;
+
+    Http::fake(function ($request) use (&$capturedUrl) {
+        $capturedUrl = $request->url();
+
+        return Http::response([
+            'routes' => [[
+                'distance' => 15000,
+                'duration' => 900,
+                'geometry' => ['coordinates' => []],
+            ]],
+        ], 200);
+    });
+
+    $service = new RoutingService;
+    $service->calculateRoute(
+        $this->startMarker,
+        $this->endMarker,
+        TransportMode::DrivingCar,
+        [
+            ['lat' => 49.0, 'lng' => 1.5],
+            ['lat' => 50.5, 'lng' => 0.5],
+        ]
+    );
+
+    expect($capturedUrl)->toContain('2.3522,48.8566;1.5,49;0.5,50.5;-0.1278,51.5074');
+});
+
+it('ignores waypoints for public transport and routes via google api', function () {
+    config(['services.google_maps.api_key' => 'test-google-key']);
+
+    $googleCalled = false;
+    $mapboxCalled = false;
+
+    Http::fake([
+        'routes.googleapis.com/*' => function () use (&$googleCalled) {
+            $googleCalled = true;
+
+            return Http::response([
+                'routes' => [[
+                    'distanceMeters' => 25000,
+                    'duration' => '1800s',
+                    'polyline' => ['encodedPolyline' => 'u{~vFvyys@'],
+                    'legs' => [[
+                        'localizedValues' => [
+                            'departure' => ['time' => ['text' => '10:00']],
+                            'arrival' => ['time' => ['text' => '10:30']],
+                        ],
+                        'steps' => [],
+                    ]],
+                ]],
+            ], 200);
+        },
+        'api.mapbox.com/*' => function () use (&$mapboxCalled) {
+            $mapboxCalled = true;
+
+            return Http::response([], 200);
+        },
+    ]);
+
+    $service = new RoutingService;
+    $service->calculateRoute(
+        $this->startMarker,
+        $this->endMarker,
+        TransportMode::PublicTransport,
+        [['lat' => 50.0, 'lng' => 1.0]] // waypoints should be ignored
+    );
+
+    expect($googleCalled)->toBeTrue()
+        ->and($mapboxCalled)->toBeFalse();
+});

--- a/tests/Unit/RoutingServiceWaypointTest.php
+++ b/tests/Unit/RoutingServiceWaypointTest.php
@@ -1,4 +1,0 @@
-<?php
-
-// RoutingService waypoint tests live in tests/Feature/RoutingServiceWaypointTest.php
-// Unit tests cannot use the Laravel application container required by RoutingService.

--- a/tests/Unit/RoutingServiceWaypointTest.php
+++ b/tests/Unit/RoutingServiceWaypointTest.php
@@ -1,0 +1,4 @@
+<?php
+
+// RoutingService waypoint tests live in tests/Feature/RoutingServiceWaypointTest.php
+// Unit tests cannot use the Laravel application container required by RoutingService.


### PR DESCRIPTION
## Summary

- Users can activate waypoint mode in the Route Panel (toggle button, disabled for public transport) and click on the map to add up to 20 intermediate waypoints
- Waypoints are shown as a numbered list with individual remove buttons and a "Clear all" option
- On route creation the waypoints are sent in the POST payload and threaded into the Mapbox Directions API coordinate string (`start;wp1;wp2;...;end`)
- Waypoints are stored as a nullable JSON column on the `routes` table and returned in the `RouteResource` API response
- Saved route waypoints are rendered on the map as small colored circles (matching the route line color) with a white stroke

## How to test

1. Open a trip with at least two markers
2. Open the Routes panel and select start/end markers + a non-public-transport mode
3. Click **Add waypoints** — the button turns active and the cursor stays as a crosshair
4. Click the map in 1–3 places; coordinates appear in the list below the button
5. Click **Calculate Route** — the route is drawn with the waypoints passed through
6. Reload the page and verify the waypoint dots are rendered on the map for the saved route
7. Validate that public transport mode hides the waypoint toggle

## Breaking changes / migrations

Requires running `php artisan migrate` (adds nullable `waypoints JSON` column to the `routes` table — already applied).

Closes #157