### PR TITLE
feat(trips): add invitation link expiry and revoke functionality

### DIFF
--- a/app/Http/Controllers/TripController.php
+++ b/app/Http/Controllers/TripController.php
@@ -212,11 +212,13 @@ class TripController extends Controller
 
         $token = $trip->generateInvitationToken($expiresAt);
 
+        $trip = $trip->fresh();
+
         return response()->json([
             'token' => $token,
             'url' => $trip->getInvitationUrl(),
-            'invitation_role' => $trip->fresh()->invitation_role,
-            'invitation_token_expires_at' => $trip->fresh()->invitation_token_expires_at?->toIso8601String(),
+            'invitation_role' => $trip->invitation_role,
+            'invitation_token_expires_at' => $trip->invitation_token_expires_at?->toIso8601String(),
         ]);
     }
 
@@ -238,7 +240,13 @@ class TripController extends Controller
      */
     public function showPreview(string $token): Response
     {
-        $trip = Trip::where('invitation_token', $token)->firstOrFail();
+        $trip = Trip::where('invitation_token', $token)->first();
+
+        if (! $trip) {
+            return Inertia::render('trips/invitation-invalid', [
+                'reason' => 'revoked',
+            ]);
+        }
 
         // Check if the invitation token has expired
         if ($trip->isInvitationTokenExpired()) {
@@ -265,7 +273,11 @@ class TripController extends Controller
      */
     public function joinTrip(string $token): JsonResponse
     {
-        $trip = Trip::where('invitation_token', $token)->firstOrFail();
+        $trip = Trip::where('invitation_token', $token)->first();
+
+        if (! $trip) {
+            throw new \App\Exceptions\BusinessLogicException('This invitation link has been revoked', 410);
+        }
 
         // Check if the invitation token has expired
         if ($trip->isInvitationTokenExpired()) {

--- a/app/Http/Controllers/TripController.php
+++ b/app/Http/Controllers/TripController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Enums\PdfTemplate;
 use App\Http\Controllers\Concerns\BuildsAdminOwnerProps;
 use App\Http\Requests\FetchTripImageRequest;
+use App\Http\Requests\GenerateInvitationTokenRequest;
 use App\Http\Requests\StoreTripRequest;
 use App\Http\Requests\UpdateTripRequest;
 use App\Models\Trip;
@@ -190,25 +191,45 @@ class TripController extends Controller
     /**
      * Generate or refresh the invitation token for a trip.
      */
-    public function generateInvitationToken(Request $request, Trip $trip): JsonResponse
+    public function generateInvitationToken(GenerateInvitationTokenRequest $request, Trip $trip): JsonResponse
     {
         $this->authorize('update', $trip);
 
-        $validated = $request->validate([
-            'invitation_role' => ['nullable', 'in:editor,viewer'],
-        ]);
+        $validated = $request->validated();
 
         if (isset($validated['invitation_role'])) {
             $trip->update(['invitation_role' => $validated['invitation_role']]);
         }
 
-        $token = $trip->generateInvitationToken();
+        $expiresAt = null;
+        if (isset($validated['expires_in']) && $validated['expires_in'] !== 'never') {
+            $expiresAt = match ($validated['expires_in']) {
+                '7_days' => now()->addDays(7),
+                '30_days' => now()->addDays(30),
+                default => null,
+            };
+        }
+
+        $token = $trip->generateInvitationToken($expiresAt);
 
         return response()->json([
             'token' => $token,
             'url' => $trip->getInvitationUrl(),
             'invitation_role' => $trip->fresh()->invitation_role,
+            'invitation_token_expires_at' => $trip->fresh()->invitation_token_expires_at?->toIso8601String(),
         ]);
+    }
+
+    /**
+     * Revoke the invitation token for a trip (invalidates the link).
+     */
+    public function revokeInvitationToken(Trip $trip): JsonResponse
+    {
+        $this->authorize('update', $trip);
+
+        $trip->revokeInvitationToken();
+
+        return response()->json(['message' => 'Invitation link revoked successfully']);
     }
 
     /**
@@ -218,6 +239,13 @@ class TripController extends Controller
     public function showPreview(string $token): Response
     {
         $trip = Trip::where('invitation_token', $token)->firstOrFail();
+
+        // Check if the invitation token has expired
+        if ($trip->isInvitationTokenExpired()) {
+            return Inertia::render('trips/invitation-invalid', [
+                'reason' => 'expired',
+            ]);
+        }
 
         // Load the trip with its markers
         $trip->load(['markers']);
@@ -238,6 +266,12 @@ class TripController extends Controller
     public function joinTrip(string $token): JsonResponse
     {
         $trip = Trip::where('invitation_token', $token)->firstOrFail();
+
+        // Check if the invitation token has expired
+        if ($trip->isInvitationTokenExpired()) {
+            throw new \App\Exceptions\BusinessLogicException('This invitation link has expired', 410);
+        }
+
         $user = auth()->user();
 
         // Check if user is already the owner

--- a/app/Http/Requests/GenerateInvitationTokenRequest.php
+++ b/app/Http/Requests/GenerateInvitationTokenRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GenerateInvitationTokenRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'invitation_role' => ['nullable', 'string', 'in:editor,viewer'],
+            'expires_in' => ['nullable', 'string', 'in:7_days,30_days,never'],
+        ];
+    }
+}

--- a/app/Models/Trip.php
+++ b/app/Models/Trip.php
@@ -31,8 +31,16 @@ class Trip extends Model
         'planned_duration_days',
         'invitation_token',
         'invitation_role',
+        'invitation_token_expires_at',
         'notes',
     ];
+
+    protected function casts(): array
+    {
+        return [
+            'invitation_token_expires_at' => 'datetime',
+        ];
+    }
 
     public function user(): BelongsTo
     {
@@ -121,13 +129,41 @@ class Trip extends Model
 
     /**
      * Generate or refresh the invitation token for this trip.
+     *
+     * @param  \Carbon\Carbon|null  $expiresAt  Optional expiry timestamp
      */
-    public function generateInvitationToken(): string
+    public function generateInvitationToken(?\Carbon\Carbon $expiresAt = null): string
     {
         $token = bin2hex(random_bytes(32));
-        $this->update(['invitation_token' => $token]);
+        $this->update([
+            'invitation_token' => $token,
+            'invitation_token_expires_at' => $expiresAt,
+        ]);
 
         return $token;
+    }
+
+    /**
+     * Revoke the invitation token for this trip (sets token and expiry to null).
+     */
+    public function revokeInvitationToken(): void
+    {
+        $this->update([
+            'invitation_token' => null,
+            'invitation_token_expires_at' => null,
+        ]);
+    }
+
+    /**
+     * Check whether the invitation token has expired.
+     */
+    public function isInvitationTokenExpired(): bool
+    {
+        if ($this->invitation_token_expires_at === null) {
+            return false;
+        }
+
+        return $this->invitation_token_expires_at->isPast();
     }
 
     /**

--- a/database/migrations/2026_03_15_184933_add_invitation_expiry_to_trips_table.php
+++ b/database/migrations/2026_03_15_184933_add_invitation_expiry_to_trips_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->timestamp('invitation_token_expires_at')->nullable()->after('invitation_role');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('trips', function (Blueprint $table) {
+            $table->dropColumn('invitation_token_expires_at');
+        });
+    }
+};

--- a/resources/js/components/invitation-dialog.tsx
+++ b/resources/js/components/invitation-dialog.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/components/ui/select';
 import { Spinner } from '@/components/ui/spinner';
 import axios from 'axios';
-import { Check, Copy } from 'lucide-react';
+import { Check, Copy, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 
 interface InvitationDialogProps {
@@ -27,6 +27,8 @@ interface InvitationDialogProps {
     isOpen: boolean;
     onClose: () => void;
 }
+
+type ExpiresIn = '7_days' | '30_days' | 'never';
 
 export default function InvitationDialog({
     tripId,
@@ -38,24 +40,36 @@ export default function InvitationDialog({
     const [invitationRole, setInvitationRole] = useState<'editor' | 'viewer'>(
         'editor',
     );
+    const [expiresIn, setExpiresIn] = useState<ExpiresIn>('never');
+    const [expiresAt, setExpiresAt] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(false);
+    const [isRevoking, setIsRevoking] = useState(false);
     const [isCopied, setIsCopied] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
     const generateInvitationLink = useCallback(
-        async (role?: 'editor' | 'viewer') => {
+        async (role?: 'editor' | 'viewer', expiry?: ExpiresIn) => {
             setIsLoading(true);
             setError(null);
 
             try {
+                const payload: Record<string, string> = {};
+                if (role !== undefined) {
+                    payload.invitation_role = role;
+                }
+                if (expiry !== undefined) {
+                    payload.expires_in = expiry;
+                }
+
                 const response = await axios.post(
                     `/trips/${tripId}/generate-invitation-token`,
-                    role !== undefined ? { invitation_role: role } : {},
+                    payload,
                 );
                 setInvitationUrl(response.data.url);
                 if (response.data.invitation_role) {
                     setInvitationRole(response.data.invitation_role);
                 }
+                setExpiresAt(response.data.invitation_token_expires_at ?? null);
             } catch (err) {
                 console.error('Error generating invitation link:', err);
                 setError(
@@ -68,6 +82,22 @@ export default function InvitationDialog({
         [tripId],
     );
 
+    const revokeInvitationLink = async () => {
+        setIsRevoking(true);
+        setError(null);
+
+        try {
+            await axios.delete(`/trips/${tripId}/revoke-invitation-token`);
+            setInvitationUrl(null);
+            setExpiresAt(null);
+        } catch (err) {
+            console.error('Error revoking invitation link:', err);
+            setError('Failed to revoke invitation link. Please try again.');
+        } finally {
+            setIsRevoking(false);
+        }
+    };
+
     useEffect(() => {
         if (isOpen && !invitationUrl) {
             void generateInvitationLink();
@@ -76,7 +106,12 @@ export default function InvitationDialog({
 
     const handleRoleChange = async (role: 'editor' | 'viewer') => {
         setInvitationRole(role);
-        await generateInvitationLink(role);
+        await generateInvitationLink(role, expiresIn);
+    };
+
+    const handleExpiryChange = async (expiry: ExpiresIn) => {
+        setExpiresIn(expiry);
+        await generateInvitationLink(invitationRole, expiry);
     };
 
     const handleCopyToClipboard = async () => {
@@ -94,7 +129,17 @@ export default function InvitationDialog({
     const handleClose = () => {
         setIsCopied(false);
         setInvitationUrl(null);
+        setExpiresAt(null);
+        setExpiresIn('never');
         onClose();
+    };
+
+    const formatExpiresAt = (iso: string): string => {
+        return new Date(iso).toLocaleDateString(undefined, {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+        });
     };
 
     return (
@@ -104,8 +149,8 @@ export default function InvitationDialog({
                     <DialogTitle>Invite to trip</DialogTitle>
                     <DialogDescription>
                         Share this link with others to let them join &ldquo;
-                        {tripName}&rdquo;. Configure the role they will receive
-                        when joining.
+                        {tripName}&rdquo;. Configure the role and expiry for the
+                        invitation link.
                     </DialogDescription>
                 </DialogHeader>
 
@@ -123,34 +168,68 @@ export default function InvitationDialog({
                     )}
 
                     {!isLoading && (
-                        <div className="space-y-2">
-                            <Label htmlFor="invitation-role">
-                                Role for new collaborators
-                            </Label>
-                            <Select
-                                value={invitationRole}
-                                onValueChange={(value) =>
-                                    void handleRoleChange(
-                                        value as 'editor' | 'viewer',
-                                    )
-                                }
-                            >
-                                <SelectTrigger
-                                    id="invitation-role"
-                                    data-testid="invitation-role-select"
+                        <>
+                            <div className="space-y-2">
+                                <Label htmlFor="invitation-role">
+                                    Role for new collaborators
+                                </Label>
+                                <Select
+                                    value={invitationRole}
+                                    onValueChange={(value) =>
+                                        void handleRoleChange(
+                                            value as 'editor' | 'viewer',
+                                        )
+                                    }
                                 >
-                                    <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectItem value="editor">
-                                        Editor — can view and edit
-                                    </SelectItem>
-                                    <SelectItem value="viewer">
-                                        Viewer — can only view
-                                    </SelectItem>
-                                </SelectContent>
-                            </Select>
-                        </div>
+                                    <SelectTrigger
+                                        id="invitation-role"
+                                        data-testid="invitation-role-select"
+                                    >
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="editor">
+                                            Editor — can view and edit
+                                        </SelectItem>
+                                        <SelectItem value="viewer">
+                                            Viewer — can only view
+                                        </SelectItem>
+                                    </SelectContent>
+                                </Select>
+                            </div>
+
+                            <div className="space-y-2">
+                                <Label htmlFor="invitation-expiry">
+                                    Link expiry
+                                </Label>
+                                <Select
+                                    value={expiresIn}
+                                    onValueChange={(value) =>
+                                        void handleExpiryChange(
+                                            value as ExpiresIn,
+                                        )
+                                    }
+                                >
+                                    <SelectTrigger
+                                        id="invitation-expiry"
+                                        data-testid="invitation-expiry-select"
+                                    >
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="never">
+                                            Never expires
+                                        </SelectItem>
+                                        <SelectItem value="7_days">
+                                            7 days
+                                        </SelectItem>
+                                        <SelectItem value="30_days">
+                                            30 days
+                                        </SelectItem>
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        </>
                     )}
 
                     {invitationUrl && !isLoading && (
@@ -182,29 +261,67 @@ export default function InvitationDialog({
                                 </Button>
                             </div>
                             <p className="text-xs text-muted-foreground">
-                                This link will remain valid as long as the trip
-                                exists. Anyone who joins via this link will
-                                receive the{' '}
-                                <strong>
-                                    {invitationRole === 'viewer'
-                                        ? 'viewer'
-                                        : 'editor'}
-                                </strong>{' '}
-                                role.
+                                {expiresAt ? (
+                                    <>
+                                        This link expires on{' '}
+                                        <strong>
+                                            {formatExpiresAt(expiresAt)}
+                                        </strong>
+                                        . Anyone who joins via this link will
+                                        receive the{' '}
+                                        <strong>
+                                            {invitationRole === 'viewer'
+                                                ? 'viewer'
+                                                : 'editor'}
+                                        </strong>{' '}
+                                        role.
+                                    </>
+                                ) : (
+                                    <>
+                                        This link will remain valid as long as
+                                        the trip exists. Anyone who joins via
+                                        this link will receive the{' '}
+                                        <strong>
+                                            {invitationRole === 'viewer'
+                                                ? 'viewer'
+                                                : 'editor'}
+                                        </strong>{' '}
+                                        role.
+                                    </>
+                                )}
                             </p>
                         </div>
                     )}
                 </div>
 
-                <DialogFooter>
-                    {error && (
-                        <Button
-                            onClick={() => void generateInvitationLink()}
-                            variant="outline"
-                        >
-                            Try again
-                        </Button>
-                    )}
+                <DialogFooter className="flex-col gap-2 sm:flex-row sm:justify-between">
+                    <div className="flex gap-2">
+                        {invitationUrl && (
+                            <Button
+                                data-testid="revoke-invitation-link-button"
+                                onClick={() => void revokeInvitationLink()}
+                                variant="destructive"
+                                size="sm"
+                                disabled={isRevoking}
+                            >
+                                {isRevoking ? (
+                                    <Spinner className="mr-2 size-4" />
+                                ) : (
+                                    <Trash2 className="mr-2 size-4" />
+                                )}
+                                Revoke link
+                            </Button>
+                        )}
+                        {error && (
+                            <Button
+                                onClick={() => void generateInvitationLink()}
+                                variant="outline"
+                                size="sm"
+                            >
+                                Try again
+                            </Button>
+                        )}
+                    </div>
                     <Button onClick={handleClose}>Close</Button>
                 </DialogFooter>
             </DialogContent>

--- a/resources/js/components/invitation-dialog.tsx
+++ b/resources/js/components/invitation-dialog.tsx
@@ -44,6 +44,7 @@ export default function InvitationDialog({
     const [expiresAt, setExpiresAt] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(false);
     const [isRevoking, setIsRevoking] = useState(false);
+    const [isRevoked, setIsRevoked] = useState(false);
     const [isCopied, setIsCopied] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
@@ -90,6 +91,7 @@ export default function InvitationDialog({
             await axios.delete(`/trips/${tripId}/revoke-invitation-token`);
             setInvitationUrl(null);
             setExpiresAt(null);
+            setIsRevoked(true);
         } catch (err) {
             console.error('Error revoking invitation link:', err);
             setError('Failed to revoke invitation link. Please try again.');
@@ -99,10 +101,10 @@ export default function InvitationDialog({
     };
 
     useEffect(() => {
-        if (isOpen && !invitationUrl) {
+        if (isOpen && !invitationUrl && !isRevoked) {
             void generateInvitationLink();
         }
-    }, [isOpen, invitationUrl, generateInvitationLink]);
+    }, [isOpen, invitationUrl, isRevoked, generateInvitationLink]);
 
     const handleRoleChange = async (role: 'editor' | 'viewer') => {
         setInvitationRole(role);
@@ -131,6 +133,7 @@ export default function InvitationDialog({
         setInvitationUrl(null);
         setExpiresAt(null);
         setExpiresIn('never');
+        setIsRevoked(false);
         onClose();
     };
 
@@ -164,6 +167,13 @@ export default function InvitationDialog({
                     {error && (
                         <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-800 dark:bg-red-900/20 dark:text-red-200">
                             {error}
+                        </div>
+                    )}
+
+                    {!isLoading && isRevoked && (
+                        <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
+                            The invitation link has been revoked. Generate a new
+                            one if you'd like to invite people again.
                         </div>
                     )}
 
@@ -310,6 +320,19 @@ export default function InvitationDialog({
                                     <Trash2 className="mr-2 size-4" />
                                 )}
                                 Revoke link
+                            </Button>
+                        )}
+                        {isRevoked && (
+                            <Button
+                                data-testid="generate-invitation-link-button"
+                                onClick={() => {
+                                    setIsRevoked(false);
+                                    void generateInvitationLink();
+                                }}
+                                variant="outline"
+                                size="sm"
+                            >
+                                Generate new link
                             </Button>
                         )}
                         {error && (

--- a/resources/js/components/invitation-dialog.tsx
+++ b/resources/js/components/invitation-dialog.tsx
@@ -151,9 +151,8 @@ export default function InvitationDialog({
                 <DialogHeader>
                     <DialogTitle>Invite to trip</DialogTitle>
                     <DialogDescription>
-                        Share this link with others to let them join &ldquo;
-                        {tripName}&rdquo;. Configure the role and expiry for the
-                        invitation link.
+                        Share this link to invite others to &ldquo;{tripName}
+                        &rdquo;.
                     </DialogDescription>
                 </DialogHeader>
 
@@ -172,8 +171,7 @@ export default function InvitationDialog({
 
                     {!isLoading && isRevoked && (
                         <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
-                            The invitation link has been revoked. Generate a new
-                            one if you'd like to invite people again.
+                            Link revoked. Generate a new one to invite people.
                         </div>
                     )}
 
@@ -273,30 +271,27 @@ export default function InvitationDialog({
                             <p className="text-xs text-muted-foreground">
                                 {expiresAt ? (
                                     <>
-                                        This link expires on{' '}
+                                        Expires{' '}
                                         <strong>
                                             {formatExpiresAt(expiresAt)}
                                         </strong>
-                                        . Anyone who joins via this link will
-                                        receive the{' '}
+                                        . Role:{' '}
                                         <strong>
                                             {invitationRole === 'viewer'
                                                 ? 'viewer'
                                                 : 'editor'}
-                                        </strong>{' '}
-                                        role.
+                                        </strong>
+                                        .
                                     </>
                                 ) : (
                                     <>
-                                        This link will remain valid as long as
-                                        the trip exists. Anyone who joins via
-                                        this link will receive the{' '}
+                                        No expiry. Role:{' '}
                                         <strong>
                                             {invitationRole === 'viewer'
                                                 ? 'viewer'
                                                 : 'editor'}
-                                        </strong>{' '}
-                                        role.
+                                        </strong>
+                                        .
                                     </>
                                 )}
                             </p>

--- a/resources/js/pages/trips/invitation-invalid.tsx
+++ b/resources/js/pages/trips/invitation-invalid.tsx
@@ -1,0 +1,52 @@
+import { Button } from '@/components/ui/button';
+import AppLayout from '@/layouts/app-layout';
+import type { BreadcrumbItem } from '@/types';
+import { Head, Link } from '@inertiajs/react';
+import { AlertTriangle, Clock } from 'lucide-react';
+
+interface InvitationInvalidProps {
+    reason: 'expired' | 'revoked';
+}
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Invitation invalid',
+        href: '#',
+    },
+];
+
+export default function TripInvitationInvalid({
+    reason,
+}: InvitationInvalidProps) {
+    const isExpired = reason === 'expired';
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Invitation invalid" />
+            <div className="flex h-full flex-1 flex-col items-center justify-center gap-6 p-6">
+                <div className="flex max-w-md flex-col items-center gap-4 text-center">
+                    <div className="flex size-16 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/20">
+                        {isExpired ? (
+                            <Clock className="size-8 text-amber-600 dark:text-amber-400" />
+                        ) : (
+                            <AlertTriangle className="size-8 text-amber-600 dark:text-amber-400" />
+                        )}
+                    </div>
+                    <h1 className="text-2xl font-semibold">
+                        {isExpired
+                            ? 'Invitation link expired'
+                            : 'Invitation link revoked'}
+                    </h1>
+                    <p className="text-muted-foreground">
+                        {isExpired
+                            ? 'This invitation link has expired. Please ask the trip owner to generate a new invitation link.'
+                            : 'This invitation link has been revoked by the trip owner. Please ask them for a new invitation link.'}
+                    </p>
+                    <Button asChild variant="outline">
+                        <Link href="/trips">Go to my trips</Link>
+                    </Button>
+                </div>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/trips/invitation-invalid.tsx
+++ b/resources/js/pages/trips/invitation-invalid.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import AppLayout from '@/layouts/app-layout';
 import type { BreadcrumbItem } from '@/types';
 import { Head, Link } from '@inertiajs/react';
-import { AlertTriangle, Clock } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
 
 interface InvitationInvalidProps {
     reason: 'expired' | 'revoked';
@@ -26,11 +26,7 @@ export default function TripInvitationInvalid({
             <div className="flex h-full flex-1 flex-col items-center justify-center gap-6 p-6">
                 <div className="flex max-w-md flex-col items-center gap-4 text-center">
                     <div className="flex size-16 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/20">
-                        {isExpired ? (
-                            <Clock className="size-8 text-amber-600 dark:text-amber-400" />
-                        ) : (
-                            <AlertTriangle className="size-8 text-amber-600 dark:text-amber-400" />
-                        )}
+                        <AlertTriangle className="size-8 text-amber-600 dark:text-amber-400" />
                     </div>
                     <h1 className="text-2xl font-semibold">
                         {isExpired

--- a/resources/js/pages/trips/invitation-invalid.tsx
+++ b/resources/js/pages/trips/invitation-invalid.tsx
@@ -35,8 +35,8 @@ export default function TripInvitationInvalid({
                     </h1>
                     <p className="text-muted-foreground">
                         {isExpired
-                            ? 'This invitation link has expired. Please ask the trip owner to generate a new invitation link.'
-                            : 'This invitation link has been revoked by the trip owner. Please ask them for a new invitation link.'}
+                            ? 'This invitation link has expired. Please ask the trip owner for a new link.'
+                            : 'This invitation link has been revoked. Please ask the trip owner for a new link.'}
                     </p>
                     <Button asChild variant="outline">
                         <Link href="/trips">Go to my trips</Link>

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('/trips/{trip}/fetch-image', [TripController::class, 'fetchImage'])->name('trips.fetch-image');
     Route::get('/trips/{trip}/export-pdf', [TripController::class, 'exportPdf'])->name('trips.export-pdf');
     Route::post('/trips/{trip}/generate-invitation-token', [TripController::class, 'generateInvitationToken'])->name('trips.generate-invitation-token');
+    Route::delete('/trips/{trip}/revoke-invitation-token', [TripController::class, 'revokeInvitationToken'])->name('trips.revoke-invitation-token');
 
     // Trip preview route (accessible with invitation token)
     Route::get('/trips/preview/{token}', [TripController::class, 'showPreview'])->name('trips.preview');

--- a/tests/Feature/TripInvitationExpiryTest.php
+++ b/tests/Feature/TripInvitationExpiryTest.php
@@ -1,0 +1,322 @@
+<?php
+
+use App\Models\Trip;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+// ─── Generate Invitation Token with Expiry ────────────────────────────────────
+
+test('owner can generate invitation token with 7-day expiry', function () {
+    $user = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $user->id]);
+
+    $response = $this
+        ->actingAs($user)
+        ->postJson("/trips/{$trip->id}/generate-invitation-token", [
+            'expires_in' => '7_days',
+        ]);
+
+    $response->assertOk();
+    $response->assertJsonStructure(['token', 'url', 'invitation_role', 'invitation_token_expires_at']);
+
+    $trip->refresh();
+    expect($trip->invitation_token_expires_at)->not->toBeNull();
+    expect($trip->invitation_token_expires_at->isFuture())->toBeTrue();
+    expect($trip->invitation_token_expires_at->isAfter(now()->addDays(6)))->toBeTrue();
+    expect($trip->invitation_token_expires_at->isBefore(now()->addDays(8)))->toBeTrue();
+});
+
+test('owner can generate invitation token with 30-day expiry', function () {
+    $user = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $user->id]);
+
+    $response = $this
+        ->actingAs($user)
+        ->postJson("/trips/{$trip->id}/generate-invitation-token", [
+            'expires_in' => '30_days',
+        ]);
+
+    $response->assertOk();
+
+    $trip->refresh();
+    expect($trip->invitation_token_expires_at)->not->toBeNull();
+    expect($trip->invitation_token_expires_at->isFuture())->toBeTrue();
+    expect($trip->invitation_token_expires_at->isAfter(now()->addDays(29)))->toBeTrue();
+    expect($trip->invitation_token_expires_at->isBefore(now()->addDays(31)))->toBeTrue();
+});
+
+test('owner can generate invitation token with no expiry', function () {
+    $user = User::factory()->create();
+    $trip = Trip::factory()->create([
+        'user_id' => $user->id,
+        'invitation_token_expires_at' => now()->subDay(),
+    ]);
+
+    $response = $this
+        ->actingAs($user)
+        ->postJson("/trips/{$trip->id}/generate-invitation-token", [
+            'expires_in' => 'never',
+        ]);
+
+    $response->assertOk();
+
+    $trip->refresh();
+    expect($trip->invitation_token_expires_at)->toBeNull();
+    $response->assertJsonPath('invitation_token_expires_at', null);
+});
+
+test('owner can generate invitation token without specifying expiry defaults to no expiry', function () {
+    $user = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $user->id]);
+
+    $response = $this
+        ->actingAs($user)
+        ->postJson("/trips/{$trip->id}/generate-invitation-token");
+
+    $response->assertOk();
+
+    $trip->refresh();
+    expect($trip->invitation_token_expires_at)->toBeNull();
+});
+
+test('expires_in validates allowed values', function () {
+    $user = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $user->id]);
+
+    $response = $this
+        ->actingAs($user)
+        ->postJson("/trips/{$trip->id}/generate-invitation-token", [
+            'expires_in' => 'invalid_value',
+        ]);
+
+    $response->assertUnprocessable();
+});
+
+// ─── Revoke Invitation Token ──────────────────────────────────────────────────
+
+test('owner can revoke invitation token', function () {
+    $user = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $user->id]);
+    $trip->generateInvitationToken();
+
+    expect($trip->fresh()->invitation_token)->not->toBeNull();
+
+    $response = $this
+        ->actingAs($user)
+        ->deleteJson("/trips/{$trip->id}/revoke-invitation-token");
+
+    $response->assertOk();
+    $response->assertJsonPath('message', 'Invitation link revoked successfully');
+
+    $trip->refresh();
+    expect($trip->invitation_token)->toBeNull();
+    expect($trip->invitation_token_expires_at)->toBeNull();
+});
+
+test('non-owner cannot revoke invitation token', function () {
+    $owner = User::factory()->create();
+    $other = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $owner->id]);
+    $trip->generateInvitationToken();
+
+    $response = $this
+        ->actingAs($other)
+        ->deleteJson("/trips/{$trip->id}/revoke-invitation-token");
+
+    $response->assertForbidden();
+});
+
+test('unauthenticated user cannot revoke invitation token', function () {
+    $user = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $user->id]);
+    $trip->generateInvitationToken();
+
+    $response = $this->deleteJson("/trips/{$trip->id}/revoke-invitation-token");
+
+    $response->assertUnauthorized();
+});
+
+// ─── Expired Token: Preview ───────────────────────────────────────────────────
+
+test('expired invitation token shows invitation-invalid page on preview', function () {
+    $owner = User::factory()->create();
+    $viewer = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $owner->id]);
+    $token = $trip->generateInvitationToken(now()->subMinute());
+
+    $response = $this
+        ->actingAs($viewer)
+        ->get("/trips/preview/{$token}");
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->component('trips/invitation-invalid')
+        ->where('reason', 'expired')
+    );
+});
+
+test('valid not yet expired invitation token shows preview page', function () {
+    $owner = User::factory()->create();
+    $viewer = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $owner->id]);
+    $token = $trip->generateInvitationToken(now()->addDays(7));
+
+    $response = $this
+        ->actingAs($viewer)
+        ->get("/trips/preview/{$token}");
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->component('trips/preview')
+    );
+});
+
+test('invitation token with no expiry shows preview page', function () {
+    $owner = User::factory()->create();
+    $viewer = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $owner->id]);
+    $token = $trip->generateInvitationToken();
+
+    $response = $this
+        ->actingAs($viewer)
+        ->get("/trips/preview/{$token}");
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->component('trips/preview')
+    );
+});
+
+// ─── Expired Token: Join ──────────────────────────────────────────────────────
+
+test('user cannot join trip with expired invitation token', function () {
+    $owner = User::factory()->create();
+    $joiner = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $owner->id]);
+    $token = $trip->generateInvitationToken(now()->subMinute());
+
+    $response = $this
+        ->actingAs($joiner)
+        ->postJson("/trips/preview/{$token}/join");
+
+    $response->assertStatus(410);
+    $response->assertJson(['error' => 'This invitation link has expired']);
+
+    $this->assertDatabaseMissing('trip_user', [
+        'trip_id' => $trip->id,
+        'user_id' => $joiner->id,
+    ]);
+});
+
+test('existing collaborators are not affected when token is revoked', function () {
+    $owner = User::factory()->create();
+    $collaborator = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $owner->id]);
+    $trip->generateInvitationToken();
+
+    $trip->sharedUsers()->attach($collaborator->id, ['collaboration_role' => 'editor']);
+
+    $this
+        ->actingAs($owner)
+        ->deleteJson("/trips/{$trip->id}/revoke-invitation-token")
+        ->assertOk();
+
+    $this->assertDatabaseHas('trip_user', [
+        'trip_id' => $trip->id,
+        'user_id' => $collaborator->id,
+        'collaboration_role' => 'editor',
+    ]);
+});
+
+// ─── Model Unit Tests ─────────────────────────────────────────────────────────
+
+test('Trip isInvitationTokenExpired returns false when no expiry set', function () {
+    $trip = Trip::factory()->create(['invitation_token_expires_at' => null]);
+
+    expect($trip->isInvitationTokenExpired())->toBeFalse();
+});
+
+test('Trip isInvitationTokenExpired returns true when expiry is in the past', function () {
+    $trip = Trip::factory()->create([
+        'invitation_token_expires_at' => now()->subDay(),
+    ]);
+
+    expect($trip->isInvitationTokenExpired())->toBeTrue();
+});
+
+test('Trip isInvitationTokenExpired returns false when expiry is in the future', function () {
+    $trip = Trip::factory()->create([
+        'invitation_token_expires_at' => now()->addDay(),
+    ]);
+
+    expect($trip->isInvitationTokenExpired())->toBeFalse();
+});
+
+test('Trip revokeInvitationToken clears token and expiry', function () {
+    $user = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $user->id]);
+    $trip->generateInvitationToken(now()->addDays(7));
+
+    expect($trip->fresh()->invitation_token)->not->toBeNull();
+    expect($trip->fresh()->invitation_token_expires_at)->not->toBeNull();
+
+    $trip->revokeInvitationToken();
+
+    $trip->refresh();
+    expect($trip->invitation_token)->toBeNull();
+    expect($trip->invitation_token_expires_at)->toBeNull();
+});
+
+test('Trip generateInvitationToken stores expiry when provided', function () {
+    $user = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $user->id]);
+    $expiresAt = now()->addDays(30);
+
+    $trip->generateInvitationToken($expiresAt);
+
+    $trip->refresh();
+    expect($trip->invitation_token_expires_at)->not->toBeNull();
+    expect($trip->invitation_token_expires_at->toDateString())->toBe($expiresAt->toDateString());
+});
+
+// ─── Role Selection ───────────────────────────────────────────────────────────
+
+test('owner can set join role when generating invitation token', function () {
+    $user = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $user->id]);
+
+    $response = $this
+        ->actingAs($user)
+        ->postJson("/trips/{$trip->id}/generate-invitation-token", [
+            'invitation_role' => 'viewer',
+        ]);
+
+    $response->assertOk();
+    $response->assertJsonPath('invitation_role', 'viewer');
+
+    $trip->refresh();
+    expect($trip->invitation_role)->toBe('viewer');
+});
+
+test('joining user receives the configured invitation role', function () {
+    $owner = User::factory()->create();
+    $joiner = User::factory()->create();
+    $trip = Trip::factory()->create([
+        'user_id' => $owner->id,
+        'invitation_role' => 'viewer',
+        'invitation_token' => 'viewer-role-token',
+    ]);
+
+    $this
+        ->actingAs($joiner)
+        ->postJson('/trips/preview/viewer-role-token/join')
+        ->assertOk();
+
+    $this->assertDatabaseHas('trip_user', [
+        'trip_id' => $trip->id,
+        'user_id' => $joiner->id,
+        'collaboration_role' => 'viewer',
+    ]);
+});

--- a/tests/Feature/TripInvitationExpiryTest.php
+++ b/tests/Feature/TripInvitationExpiryTest.php
@@ -269,16 +269,48 @@ test('Trip revokeInvitationToken clears token and expiry', function () {
     expect($trip->invitation_token_expires_at)->toBeNull();
 });
 
-test('Trip generateInvitationToken stores expiry when provided', function () {
-    $user = User::factory()->create();
-    $trip = Trip::factory()->create(['user_id' => $user->id]);
-    $expiresAt = now()->addDays(30);
+// ─── Revoked Token: Preview & Join ───────────────────────────────────────────
 
-    $trip->generateInvitationToken($expiresAt);
+test('revoked invitation token shows invitation-invalid page with reason revoked on preview', function () {
+    $owner = User::factory()->create();
+    $viewer = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $owner->id]);
+    $token = $trip->generateInvitationToken();
 
-    $trip->refresh();
-    expect($trip->invitation_token_expires_at)->not->toBeNull();
-    expect($trip->invitation_token_expires_at->toDateString())->toBe($expiresAt->toDateString());
+    // Revoke the token
+    $this->actingAs($owner)->deleteJson("/trips/{$trip->id}/revoke-invitation-token")->assertOk();
+
+    $response = $this
+        ->actingAs($viewer)
+        ->get("/trips/preview/{$token}");
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->component('trips/invitation-invalid')
+        ->where('reason', 'revoked')
+    );
+});
+
+test('user cannot join trip with revoked invitation token', function () {
+    $owner = User::factory()->create();
+    $joiner = User::factory()->create();
+    $trip = Trip::factory()->create(['user_id' => $owner->id]);
+    $token = $trip->generateInvitationToken();
+
+    // Revoke the token
+    $this->actingAs($owner)->deleteJson("/trips/{$trip->id}/revoke-invitation-token")->assertOk();
+
+    $response = $this
+        ->actingAs($joiner)
+        ->postJson("/trips/preview/{$token}/join");
+
+    $response->assertStatus(410);
+    $response->assertJson(['error' => 'This invitation link has been revoked']);
+
+    $this->assertDatabaseMissing('trip_user', [
+        'trip_id' => $trip->id,
+        'user_id' => $joiner->id,
+    ]);
 });
 
 // ─── Role Selection ───────────────────────────────────────────────────────────

--- a/tests/Feature/TripInvitationTest.php
+++ b/tests/Feature/TripInvitationTest.php
@@ -82,14 +82,18 @@ test('unauthenticated user cannot access trip preview', function () {
     $response->assertRedirect(route('login'));
 });
 
-test('trip preview returns 404 for invalid token', function () {
+test('trip preview returns invitation-invalid page for unknown token', function () {
     $user = User::factory()->create();
 
     $response = $this
         ->actingAs($user)
         ->get('/trips/preview/invalid-token');
 
-    $response->assertNotFound();
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->component('trips/invitation-invalid')
+        ->where('reason', 'revoked')
+    );
 });
 
 test('trip preview includes markers', function () {

--- a/tests/Feature/TripJoinTest.php
+++ b/tests/Feature/TripJoinTest.php
@@ -138,10 +138,11 @@ test('unauthenticated user cannot join trip', function () {
     $response->assertStatus(401);
 });
 
-test('joining trip with invalid token returns 404', function () {
+test('joining trip with invalid token returns 410', function () {
     $response = $this->actingAs($this->user)->postJson('/trips/preview/invalid-token/join');
 
-    $response->assertStatus(404);
+    $response->assertStatus(410);
+    $response->assertJson(['error' => 'This invitation link has been revoked']);
 });
 
 test('owner sees collaborator status on their own trip preview', function () {


### PR DESCRIPTION
## Summary

- Adds optional expiry to invitation links (7 days, 30 days, or never)
- Adds revoke functionality so trip owners can invalidate invitation links
- Shows a clear in-app error page when a link is expired or revoked
- Existing collaborators are **not** affected when a link is revoked or expires

## Changes

### Backend
- **Migration**: adds `invitation_token_expires_at` (nullable timestamp) to `trips`
- **`Trip` model**: new `revokeInvitationToken()`, `isInvitationTokenExpired()`, updated `generateInvitationToken()` to accept optional expiry, added cast for new column
- **`GenerateInvitationTokenRequest`**: validates `invitation_role` and `expires_in` (`7_days` | `30_days` | `never`)
- **`TripController`**: updated `generateInvitationToken()` and `showPreview()` + `joinTrip()` to check expiry; new `revokeInvitationToken()` action
- **Routes**: `DELETE /trips/{trip}/revoke-invitation-token`

### Frontend
- **`invitation-dialog.tsx`**: expiry selector, shows human-readable expiry date, "Revoke link" destructive button with loading state
- **`trips/invitation-invalid.tsx`**: new Inertia page shown for expired/revoked links, supports dark mode

### Tests
- `tests/Feature/TripInvitationExpiryTest.php`: 20 new Pest tests covering all acceptance criteria

## How to test

1. Run `php artisan migrate`
2. Open a trip's share dialog — you should see an expiry selector and a "Revoke link" button
3. Generate a link with a 7-day expiry; the expiry date should appear in the dialog
4. Visit the generated link — it should work normally
5. Revoke the link and visit the old URL — you should see the "invitation-invalid" page
6. Manually set `invitation_token_expires_at` to the past in the DB and visit the link — you should see the expired page
7. Confirm that existing trip collaborators are unaffected by revocation

## QA results

- `php artisan test --compact` → **730 passed, 1 skipped**
- `vendor/bin/pint --dirty` → no changes
- `npm run format` → no changes
- `npm run build` → success

Closes #491