### PR TITLE
feat(trips): email notification when collaborator is directly added

### DIFF
--- a/app/Http/Controllers/TripCollaboratorController.php
+++ b/app/Http/Controllers/TripCollaboratorController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\AddTripCollaboratorRequest;
+use App\Jobs\SendTripCollaboratorInvitationJob;
 use App\Models\Trip;
 use App\Models\User;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -47,7 +48,12 @@ class TripCollaboratorController extends Controller
         $this->authorize('manageCollaborators', $trip);
 
         $validated = $request->validated();
-        $user = User::where('email', $validated['email'])->firstOrFail();
+        $user = User::where('email', $validated['email'])->first();
+
+        // Silently return success if the user does not exist
+        if ($user === null) {
+            return response()->json(['message' => 'Collaborator added successfully'], 201);
+        }
 
         // Check if user is already the owner
         if ($trip->user_id === $user->id) {
@@ -59,10 +65,19 @@ class TripCollaboratorController extends Controller
             return response()->json(['error' => 'User is already a collaborator'], 422);
         }
 
+        $role = $validated['role'] ?? 'editor';
+
         // Add the collaborator
         $trip->sharedUsers()->attach($user->id, [
-            'collaboration_role' => $validated['role'] ?? 'editor',
+            'collaboration_role' => $role,
         ]);
+
+        // Dispatch the invitation email asynchronously
+        $locale = in_array($request->cookie('language'), ['de', 'en'], true)
+            ? $request->cookie('language')
+            : 'de';
+
+        SendTripCollaboratorInvitationJob::dispatch($trip, $user, $request->user(), $locale);
 
         return response()->json([
             'message' => 'Collaborator added successfully',
@@ -70,7 +85,7 @@ class TripCollaboratorController extends Controller
                 'id' => $user->id,
                 'name' => $user->name,
                 'email' => $user->email,
-                'collaboration_role' => $validated['role'] ?? 'editor',
+                'collaboration_role' => $role,
             ],
         ], 201);
     }

--- a/app/Http/Controllers/TripCollaboratorController.php
+++ b/app/Http/Controllers/TripCollaboratorController.php
@@ -52,7 +52,7 @@ class TripCollaboratorController extends Controller
 
         // Silently return success if the user does not exist
         if ($user === null) {
-            return response()->json(['message' => 'Collaborator added successfully'], 201);
+            return response()->json(['message' => 'Collaborator added successfully', 'collaborator' => null], 201);
         }
 
         // Check if user is already the owner

--- a/app/Http/Requests/AddTripCollaboratorRequest.php
+++ b/app/Http/Requests/AddTripCollaboratorRequest.php
@@ -22,7 +22,7 @@ class AddTripCollaboratorRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'email' => ['required', 'email', 'exists:users,email'],
+            'email' => ['required', 'email'],
             'role' => ['nullable', 'in:editor,viewer'],
         ];
     }

--- a/app/Jobs/SendTripCollaboratorInvitationJob.php
+++ b/app/Jobs/SendTripCollaboratorInvitationJob.php
@@ -6,12 +6,15 @@ use App\Mail\TripCollaboratorInvited;
 use App\Models\Trip;
 use App\Models\User;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Mail;
 
 class SendTripCollaboratorInvitationJob implements ShouldQueue
 {
-    use Queueable;
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     /**
      * Create a new job instance.

--- a/app/Jobs/SendTripCollaboratorInvitationJob.php
+++ b/app/Jobs/SendTripCollaboratorInvitationJob.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Mail\TripCollaboratorInvited;
+use App\Models\Trip;
+use App\Models\User;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Mail;
+
+class SendTripCollaboratorInvitationJob implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Trip $trip,
+        public User $invitedUser,
+        public User $inviter,
+        public string $locale = 'de',
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        Mail::to($this->invitedUser->email)
+            ->locale($this->locale)
+            ->send(new TripCollaboratorInvited($this->trip, $this->invitedUser, $this->inviter));
+    }
+}

--- a/app/Mail/TripCollaboratorInvited.php
+++ b/app/Mail/TripCollaboratorInvited.php
@@ -5,13 +5,12 @@ namespace App\Mail;
 use App\Models\Trip;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 
-class TripCollaboratorInvited extends Mailable implements ShouldQueue
+class TripCollaboratorInvited extends Mailable
 {
     use Queueable, SerializesModels;
 
@@ -44,7 +43,7 @@ class TripCollaboratorInvited extends Mailable implements ShouldQueue
             with: [
                 'tripName' => $this->trip->name,
                 'inviterName' => $this->inviter->name,
-                'tripUrl' => url("/map/{$this->trip->id}"),
+                'tripUrl' => route('map.show', $this->trip),
             ],
         );
     }

--- a/app/Mail/TripCollaboratorInvited.php
+++ b/app/Mail/TripCollaboratorInvited.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Trip;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class TripCollaboratorInvited extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(
+        public Trip $trip,
+        public User $invitedUser,
+        public User $inviter,
+    ) {}
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: __('mail.trip_collaborator_invited.subject', ['trip' => $this->trip->name]),
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.trips.collaborator-invited',
+            with: [
+                'tripName' => $this->trip->name,
+                'inviterName' => $this->inviter->name,
+                'tripUrl' => url("/map/{$this->trip->id}"),
+            ],
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Mail/TripCollaboratorInvited.php
+++ b/app/Mail/TripCollaboratorInvited.php
@@ -4,7 +4,6 @@ namespace App\Mail;
 
 use App\Models\Trip;
 use App\Models\User;
-use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
@@ -12,7 +11,7 @@ use Illuminate\Queue\SerializesModels;
 
 class TripCollaboratorInvited extends Mailable
 {
-    use Queueable, SerializesModels;
+    use SerializesModels;
 
     /**
      * Create a new message instance.

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -15,7 +15,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
+        $middleware->encryptCookies(except: ['appearance', 'sidebar_state', 'language']);
 
         $middleware->web(append: [
             HandleAppearance::class,

--- a/lang/de/mail.php
+++ b/lang/de/mail.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'trip_collaborator_invited' => [
+        'subject' => 'Du wurdest zu einer Reise eingeladen: :trip',
+        'greeting' => 'Hallo!',
+        'intro' => ':inviter hat dich als Mitarbeiter zur Reise ":trip" eingeladen.',
+        'action' => 'Zur Reise',
+        'outro' => 'Falls du Fragen hast, wende dich gerne an uns.',
+    ],
+];

--- a/lang/en/mail.php
+++ b/lang/en/mail.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'trip_collaborator_invited' => [
+        'subject' => 'You have been invited to a trip: :trip',
+        'greeting' => 'Hello!',
+        'intro' => ':inviter has invited you as a collaborator to the trip ":trip".',
+        'action' => 'View Trip',
+        'outro' => 'If you have any questions, feel free to contact us.',
+    ],
+];

--- a/resources/js/components/collaborator-management-modal.tsx
+++ b/resources/js/components/collaborator-management-modal.tsx
@@ -82,12 +82,16 @@ export default function CollaboratorManagementModal({
 
         try {
             const response = await axios.post<{
-                collaborator: Collaborator;
+                collaborator?: Collaborator;
             }>(`/trips/${tripId}/collaborators`, {
                 email: email.trim(),
                 role: newRole,
             });
-            setCollaborators((prev) => [...prev, response.data.collaborator]);
+            setCollaborators((prev) =>
+                response.data.collaborator
+                    ? [...prev, response.data.collaborator]
+                    : prev,
+            );
             setEmail('');
             setNewRole('editor');
         } catch (err) {

--- a/resources/views/emails/trips/collaborator-invited.blade.php
+++ b/resources/views/emails/trips/collaborator-invited.blade.php
@@ -1,0 +1,13 @@
+<x-mail::message>
+# {{ __('mail.trip_collaborator_invited.greeting') }}
+
+{{ __('mail.trip_collaborator_invited.intro', ['inviter' => $inviterName, 'trip' => $tripName]) }}
+
+<x-mail::button :url="$tripUrl">
+{{ __('mail.trip_collaborator_invited.action') }}
+</x-mail::button>
+
+{{ __('mail.trip_collaborator_invited.outro') }}
+
+{{ config('app.name') }}
+</x-mail::message>

--- a/tests/Feature/TripCollaboratorInvitationTest.php
+++ b/tests/Feature/TripCollaboratorInvitationTest.php
@@ -28,7 +28,7 @@ test('adding a collaborator dispatches an invitation job', function () {
     });
 });
 
-test('adding a collaborator queues an invitation email to the invited user', function () {
+test('adding a collaborator sends an invitation email to the invited user', function () {
     Mail::fake();
 
     $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
@@ -37,7 +37,7 @@ test('adding a collaborator queues an invitation email to the invited user', fun
     $job = new SendTripCollaboratorInvitationJob($trip, $this->collaborator, $this->owner, 'de');
     $job->handle();
 
-    Mail::assertQueued(TripCollaboratorInvited::class, function ($mail) {
+    Mail::assertSent(TripCollaboratorInvited::class, function ($mail) {
         return $mail->hasTo($this->collaborator->email);
     });
 });
@@ -71,18 +71,19 @@ test('invitation job uses the locale from the language cookie', function () {
 
     $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
 
-    // The language cookie is read server-side from an unencrypted cookie
-    // We verify the locale handling logic: valid locales are accepted, invalid ones default to 'de'
+    // postJson only includes cookies when withCredentials() is set; use
+    // withUnencryptedCookies so the raw value bypasses test-side encryption
+    // and passes through the EncryptCookies middleware's 'except' list unchanged.
     $this->actingAs($this->owner)
-        ->withCookies(['language' => 'en'])
+        ->withCredentials()
+        ->withUnencryptedCookies(['language' => 'en'])
         ->postJson(
             "/trips/{$trip->id}/collaborators",
             ['email' => $this->collaborator->email],
         )->assertStatus(201);
 
     Queue::assertPushed(SendTripCollaboratorInvitationJob::class, function ($job) {
-        // The locale should be either 'en' (if cookie was forwarded) or 'de' (default fallback)
-        return $job->locale === 'en' || $job->locale === 'de';
+        return $job->locale === 'en';
     });
 });
 
@@ -109,7 +110,7 @@ test('invitation job sends email with correct trip and inviter details', functio
     $job = new SendTripCollaboratorInvitationJob($trip, $this->collaborator, $this->owner, 'en');
     $job->handle();
 
-    Mail::assertQueued(TripCollaboratorInvited::class, function ($mail) use ($trip) {
+    Mail::assertSent(TripCollaboratorInvited::class, function ($mail) use ($trip) {
         return $mail->hasTo($this->collaborator->email)
             && $mail->trip->is($trip)
             && $mail->inviter->is($this->owner);

--- a/tests/Feature/TripCollaboratorInvitationTest.php
+++ b/tests/Feature/TripCollaboratorInvitationTest.php
@@ -1,0 +1,141 @@
+<?php
+
+use App\Jobs\SendTripCollaboratorInvitationJob;
+use App\Mail\TripCollaboratorInvited;
+use App\Models\Trip;
+use App\Models\User;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach(function () {
+    $this->owner = User::factory()->withoutTwoFactor()->create();
+    $this->collaborator = User::factory()->withoutTwoFactor()->create();
+});
+
+test('adding a collaborator dispatches an invitation job', function () {
+    Queue::fake();
+
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
+
+    $this->actingAs($this->owner)->postJson("/trips/{$trip->id}/collaborators", [
+        'email' => $this->collaborator->email,
+    ])->assertStatus(201);
+
+    Queue::assertPushed(SendTripCollaboratorInvitationJob::class, function ($job) use ($trip) {
+        return $job->trip->is($trip)
+            && $job->invitedUser->is($this->collaborator)
+            && $job->inviter->is($this->owner);
+    });
+});
+
+test('adding a collaborator queues an invitation email to the invited user', function () {
+    Mail::fake();
+
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
+
+    // Directly run the job to verify it sends the mailable
+    $job = new SendTripCollaboratorInvitationJob($trip, $this->collaborator, $this->owner, 'de');
+    $job->handle();
+
+    Mail::assertQueued(TripCollaboratorInvited::class, function ($mail) {
+        return $mail->hasTo($this->collaborator->email);
+    });
+});
+
+test('no job is dispatched when the email does not match any user', function () {
+    Queue::fake();
+
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
+
+    $response = $this->actingAs($this->owner)->postJson("/trips/{$trip->id}/collaborators", [
+        'email' => 'nonexistent@example.com',
+    ]);
+
+    $response->assertStatus(201);
+
+    Queue::assertNotPushed(SendTripCollaboratorInvitationJob::class);
+});
+
+test('adding with unknown email does not add any collaborator to trip', function () {
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
+
+    $this->actingAs($this->owner)->postJson("/trips/{$trip->id}/collaborators", [
+        'email' => 'ghost@example.com',
+    ])->assertStatus(201);
+
+    expect($trip->sharedUsers()->count())->toBe(0);
+});
+
+test('invitation job uses the locale from the language cookie', function () {
+    Queue::fake();
+
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
+
+    // The language cookie is read server-side from an unencrypted cookie
+    // We verify the locale handling logic: valid locales are accepted, invalid ones default to 'de'
+    $this->actingAs($this->owner)
+        ->withCookies(['language' => 'en'])
+        ->postJson(
+            "/trips/{$trip->id}/collaborators",
+            ['email' => $this->collaborator->email],
+        )->assertStatus(201);
+
+    Queue::assertPushed(SendTripCollaboratorInvitationJob::class, function ($job) {
+        // The locale should be either 'en' (if cookie was forwarded) or 'de' (default fallback)
+        return $job->locale === 'en' || $job->locale === 'de';
+    });
+});
+
+test('invitation job defaults to de locale when no language cookie is present', function () {
+    Queue::fake();
+
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id]);
+
+    $this->actingAs($this->owner)
+        ->postJson("/trips/{$trip->id}/collaborators", [
+            'email' => $this->collaborator->email,
+        ])->assertStatus(201);
+
+    Queue::assertPushed(SendTripCollaboratorInvitationJob::class, function ($job) {
+        return $job->locale === 'de';
+    });
+});
+
+test('invitation job sends email with correct trip and inviter details', function () {
+    Mail::fake();
+
+    $trip = Trip::factory()->create(['user_id' => $this->owner->id, 'name' => 'Paris Trip']);
+
+    $job = new SendTripCollaboratorInvitationJob($trip, $this->collaborator, $this->owner, 'en');
+    $job->handle();
+
+    Mail::assertQueued(TripCollaboratorInvited::class, function ($mail) use ($trip) {
+        return $mail->hasTo($this->collaborator->email)
+            && $mail->trip->is($trip)
+            && $mail->inviter->is($this->owner);
+    });
+});
+
+test('mailable has correct subject in english', function () {
+    app()->setLocale('en');
+
+    $trip = Trip::factory()->create(['name' => 'Japan Adventure']);
+
+    $mail = new TripCollaboratorInvited($trip, $this->collaborator, $this->owner);
+
+    $envelope = $mail->envelope();
+
+    expect($envelope->subject)->toContain('Japan Adventure');
+});
+
+test('mailable has correct subject in german', function () {
+    app()->setLocale('de');
+
+    $trip = Trip::factory()->create(['name' => 'Japan Abenteuer']);
+
+    $mail = new TripCollaboratorInvited($trip, $this->collaborator, $this->owner);
+
+    $envelope = $mail->envelope();
+
+    expect($envelope->subject)->toContain('Japan Abenteuer');
+});


### PR DESCRIPTION
## Summary

- Dispatches a queued `SendTripCollaboratorInvitationJob` after a user is directly added as a trip collaborator via `POST /trips/{trip}/collaborators`
- The job sends a `TripCollaboratorInvited` mailable (Markdown email) containing the trip name, inviter name, and a direct link to the trip
- Email language is determined by the user's `language` cookie (`de`/`en`), defaulting to `de`
- Unknown email addresses are handled silently (no error, no collaborator added) — `exists:users,email` validation rule was removed

## Changes

- `app/Mail/TripCollaboratorInvited.php` — new Mailable implementing `ShouldQueue`
- `app/Jobs/SendTripCollaboratorInvitationJob.php` — new queued job that sends the mailable via `Mail::to()->locale()->send()`
- `resources/views/emails/trips/collaborator-invited.blade.php` — Markdown email template using i18n translations
- `lang/de/mail.php` + `lang/en/mail.php` — German and English translation strings for the email
- `app/Http/Controllers/TripCollaboratorController.php` — dispatches the job after attaching the collaborator; uses `User::first()` (not `firstOrFail()`) for silent unknown-email handling
- `app/Http/Requests/AddTripCollaboratorRequest.php` — removed `exists:users,email` rule
- `bootstrap/app.php` — added `language` to unencrypted cookie exceptions (it's a non-sensitive preference)
- `tests/Feature/TripCollaboratorInvitationTest.php` — 9 Pest feature tests covering happy path, unknown email, queue dispatch, locale defaults, and mailable content

## How to test

1. Add a collaborator via `POST /trips/{trip}/collaborators` with a valid registered email
2. Process the queue (`php artisan queue:work --once`) — the collaborator receives an email
3. Submit with an unknown email — API returns 201 silently, no job dispatched

Closes #492