### PR TITLE
ci: add concurrency groups to all PR and branch workflows

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -10,6 +10,10 @@ on:
     branches: [main]
     types: [opened, synchronize, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('branch-{0}', github.ref) }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/guard-rails.yml
+++ b/.github/workflows/guard-rails.yml
@@ -10,6 +10,10 @@ on:
     branches: [main]
     types: [opened, synchronize, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   # For direct branch pushes: cancel previous runs on the same branch.
-  # For workflow_call: use the caller's run ID so parallel callers never cancel each other.
+  # For workflow_call: use this workflow run's ID (run_id is unique per invocation) so parallel callers never cancel each other.
   group: ${{ github.workflow }}-${{ github.event_name == 'workflow_call' && github.run_id || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'workflow_call' }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,12 @@ on:
       - copilot/*
   workflow_call:
 
+concurrency:
+  # For direct branch pushes: cancel previous runs on the same branch.
+  # For workflow_call: use the caller's run ID so parallel callers never cancel each other.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_call' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_call' }}
+
 permissions:
   contents: write
 

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -10,6 +10,10 @@ on:
     branches: [main]
     types: [opened, synchronize, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   # For direct branch pushes: cancel previous runs on the same branch.
-  # For workflow_call: use the caller's run ID so parallel callers never cancel each other.
+  # For workflow_call: use this workflow run's ID so each invocation has a unique group and parallel callers never cancel each other.
   group: ${{ github.workflow }}-${{ github.event_name == 'workflow_call' && github.run_id || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'workflow_call' }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,12 @@ on:
       - copilot/*
   workflow_call:
 
+concurrency:
+  # For direct branch pushes: cancel previous runs on the same branch.
+  # For workflow_call: use the caller's run ID so parallel callers never cancel each other.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_call' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_call' }}
+
 jobs:
   unit-tests:
     name: Unit and Feature Tests


### PR DESCRIPTION
## Summary

- Adds `concurrency` blocks to all six workflow files that were missing them
- Prevents duplicate CI runs when multiple pushes happen in rapid succession on the same branch/PR
- Eliminates conflicting AI review comments from parallel runs on the same PR

## Changes

| Workflow | Trigger | Group key |
|---|---|---|
| `ci.yml` | `push` + `pull_request` | PR number (for PRs) or `ref` (for branch pushes) |
| `guard-rails.yml` | `pull_request` only | PR number |
| `ai-review.yml` | `pull_request` only | PR number |
| `quality-gate.yml` | `pull_request` only | PR number |
| `lint.yml` | `push` on feature/copilot branches + `workflow_call` | `ref` for pushes; `run_id` for `workflow_call` (avoids cancelling caller-initiated runs) |
| `tests.yml` | `push` on feature/copilot branches + `workflow_call` | same as lint |

The `workflow_call` case uses `github.run_id` as the group key so reusable workflow invocations from `ci.yml` are never cancelled by each other.

## How to test

Push two commits in rapid succession to any feature branch — the first CI run should be cancelled and only the latest run completes.

Closes #507