### PR TITLE
ci: implement develop branching model and release workflow

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }}
+
       - name: Get PHP diff
         id: diff
         run: |
@@ -111,6 +114,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }}
 
       - name: Check if frontend files changed
         id: frontend
@@ -199,6 +205,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }}
 
       - name: Deterministic secret scan (no AI needed)
         run: |
@@ -295,6 +304,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }}
 
       - name: Check if migrations changed
         id: migrations

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -7,7 +7,7 @@ name: AI Code Review
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     types: [opened, synchronize, ready_for_review]
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
     branches:
       - main
+      - develop
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('branch-{0}', github.ref) }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -23,6 +23,8 @@ jobs:
     name: Run Tests (manual dispatch only)
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/tests.yml
+    with:
+      ref: ${{ inputs.ref || github.sha }}
 
   # Deployment (nur wenn CI erfolgreich war, oder bei manuellem Trigger)
   deploy:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,13 +1,18 @@
 name: Deploy to DEV
 
 on:
-  # Trigger only after CI has completed successfully on main — avoids running
+  # Trigger only after CI has completed successfully on develop — avoids running
   # tests a second time (ci.yml already ran them before this workflow starts).
   workflow_run:
     workflows: ['CI']
     types: [completed]
-    branches: [main]
-  workflow_dispatch: # Manuelles Deployment erlauben
+    branches: [develop]
+  workflow_dispatch: # Manuelles Deployment erlauben (Branch wählbar)
+    inputs:
+      ref:
+        description: 'Branch or SHA to deploy (default: develop)'
+        required: false
+        default: 'develop'
 
 permissions:
   contents: read
@@ -39,7 +44,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha || inputs.ref || github.sha }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,7 +1,19 @@
 name: Deploy to PROD
 
 on:
-  workflow_dispatch: # Nur manuelles Deployment erlauben
+  # Automatically triggered when release.yml merges develop → main
+  push:
+    branches: [main]
+    # Only deploy on version tags or the merge commit from release.yml;
+    # guard against direct pushes by checking tag pattern in the deploy job.
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch: # Nur manuelles Deployment erlauben (Tag wählbar)
+    inputs:
+      ref:
+        description: 'Tag or SHA to deploy (e.g. v1.2.3)'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -23,6 +35,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,14 +1,13 @@
 name: Deploy to PROD
 
 on:
-  # Automatically triggered when release.yml merges develop → main
+  # Automatically triggered when post-merge.yml creates a version tag after
+  # release.yml merges develop → main. Using tag-only trigger prevents
+  # duplicate deployments on changelog/follow-up commits to main.
   push:
-    branches: [main]
-    # Only deploy on version tags or the merge commit from release.yml;
-    # guard against direct pushes by checking tag pattern in the deploy job.
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-  workflow_dispatch: # Nur manuelles Deployment erlauben (Tag wählbar)
+      - 'v[0-9]*.[0-9]*.[0-9]*'
+  workflow_dispatch: # Manuelles Deployment (Tag oder SHA wählbar)
     inputs:
       ref:
         description: 'Tag or SHA to deploy (e.g. v1.2.3)'

--- a/.github/workflows/guard-rails.yml
+++ b/.github/workflows/guard-rails.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }}
+
       - name: Validate branch naming
         run: |
           BRANCH="${{ github.head_ref }}"
@@ -98,6 +101,11 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -166,19 +174,18 @@ jobs:
           HEAD_ERRORS=$(npm run types 2>&1 | grep -c "error TS" || true)
           echo "TypeScript errors on this branch: $HEAD_ERRORS"
 
-          # Count errors on main
-          git fetch origin main --depth=1
+          # Count errors on base branch (already fetched above)
           git stash --include-untracked || true
           git checkout origin/${{ github.base_ref }} -- tsconfig.json resources/js 2>/dev/null || true
           BASE_ERRORS=$(npm run types 2>&1 | grep -c "error TS" || true)
-          echo "TypeScript errors on main: $BASE_ERRORS"
+          echo "TypeScript errors on ${{ github.base_ref }}: $BASE_ERRORS"
 
           # Restore our branch files
           git checkout HEAD -- tsconfig.json resources/js 2>/dev/null || true
           git stash pop 2>/dev/null || true
 
           if [[ $HEAD_ERRORS -gt $BASE_ERRORS ]]; then
-            echo "::error::This PR introduced $((HEAD_ERRORS - BASE_ERRORS)) new TypeScript error(s) ($BASE_ERRORS on main → $HEAD_ERRORS on this branch)."
+            echo "::error::This PR introduced $((HEAD_ERRORS - BASE_ERRORS)) new TypeScript error(s) ($BASE_ERRORS on ${{ github.base_ref }} → $HEAD_ERRORS on this branch)."
             exit 1
           fi
-          echo "No new TypeScript errors introduced (main: $BASE_ERRORS, this branch: $HEAD_ERRORS)."
+          echo "No new TypeScript errors introduced (${{ github.base_ref }}: $BASE_ERRORS, this branch: $HEAD_ERRORS)."

--- a/.github/workflows/guard-rails.yml
+++ b/.github/workflows/guard-rails.yml
@@ -1,13 +1,13 @@
 name: Guard Rails
 
-# Stage 1 — Runs on every feature/copilot PR targeting main.
+# Stage 1 — Runs on every feature/copilot PR targeting develop or main.
 # Agents: Git Workflow Master + DevOps Automator
 # Checks branch naming, conventional commits, PR issue link,
 # Pint formatting, Prettier, ESLint, and TypeScript types.
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     types: [opened, synchronize, ready_for_review]
 
 concurrency:
@@ -49,7 +49,7 @@ jobs:
       - name: Validate commit messages (Conventional Commits)
         run: |
           # Get all commit subjects added in this PR (not on main)
-          COMMITS=$(git log origin/main..HEAD --no-merges --format="%s")
+          COMMITS=$(git log origin/${{ github.base_ref }}..HEAD --no-merges --format="%s")
           if [[ -z "$COMMITS" ]]; then
             echo "No new commits to validate."
             exit 0
@@ -169,7 +169,7 @@ jobs:
           # Count errors on main
           git fetch origin main --depth=1
           git stash --include-untracked || true
-          git checkout origin/main -- tsconfig.json resources/js 2>/dev/null || true
+          git checkout origin/${{ github.base_ref }} -- tsconfig.json resources/js 2>/dev/null || true
           BASE_ERRORS=$(npm run types 2>&1 | grep -c "error TS" || true)
           echo "TypeScript errors on main: $BASE_ERRORS"
 

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }}
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -214,6 +217,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }}
 
       - name: Check if frontend files changed
         id: frontend

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -7,7 +7,7 @@ name: Quality Gate
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     types: [opened, synchronize, ready_for_review]
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Get commits since last tag
         id: commits
         run: |
@@ -59,9 +64,10 @@ jobs:
           echo "last_tag=$LAST_TAG" >> $GITHUB_OUTPUT
 
           if [[ -z "$LAST_TAG" ]]; then
-            COMMITS=$(git log --format="%s" -30)
+            # Include both subject and body so BREAKING CHANGE footers are detected
+            COMMITS=$(git log --format="%B" -30)
           else
-            COMMITS=$(git log "${LAST_TAG}..HEAD" --format="%s")
+            COMMITS=$(git log "${LAST_TAG}..HEAD" --format="%B")
           fi
 
           echo "$COMMITS" > /tmp/commits.txt
@@ -90,7 +96,7 @@ jobs:
               BUMP="minor"
             elif [[ "$OVERRIDE" == "patch" ]]; then
               BUMP="patch"
-            elif echo "$COMMITS" | grep -qE '(feat|fix|refactor|perf)!:|BREAKING CHANGE'; then
+            elif echo "$COMMITS" | grep -qE '(\(.+\))?!:|BREAKING CHANGE'; then
               BUMP="major"
             elif echo "$COMMITS" | grep -qE '^feat(\(.+\))?:'; then
               BUMP="minor"
@@ -159,7 +165,7 @@ jobs:
             echo "No version files changed — skipping bump commit."
             echo "committed=false" >> $GITHUB_OUTPUT
           else
-            git commit -m "chore: bump version to ${VERSION} [skip ci]"
+            git commit -m "chore: bump version to ${VERSION}"
             echo "committed=true" >> $GITHUB_OUTPUT
             echo "Committed version bump for $VERSION"
           fi
@@ -200,7 +206,8 @@ jobs:
 
           git fetch origin main
           git checkout main
-          git merge --no-ff origin/develop -m "chore: release ${VERSION} — merge develop into main"
+          # Merge the local develop branch (already up-to-date after push above)
+          git merge --no-ff develop -m "chore: release ${VERSION} — merge develop into main"
           git push origin main
 
           echo "develop merged into main for release $VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,23 @@ jobs:
     environment: production
 
     steps:
+      - name: Validate automation token
+        env:
+          TOKEN: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
+        run: |
+          if [[ -z "$TOKEN" ]]; then
+            echo "::error::PROJECT_AUTOMATION_TOKEN secret is required."
+            echo "::error::Pushes with GITHUB_TOKEN do not trigger downstream workflows (post-merge.yml, deploy-prod.yml)."
+            echo "::error::Add a PAT with 'contents:write' scope as PROJECT_AUTOMATION_TOKEN in repository secrets."
+            exit 1
+          fi
+
       - name: Checkout develop
         uses: actions/checkout@v4
         with:
           ref: develop
           fetch-depth: 0
-          token: ${{ secrets.PROJECT_AUTOMATION_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
 
       - name: Configure git
         run: |
@@ -85,6 +96,7 @@ jobs:
 
           if [[ -z "$LAST_TAG" ]]; then
             NEXT="v1.0.0"
+            BUMP="initial"
           else
             MAJOR=$(echo "$LAST_TAG" | sed 's/v//' | cut -d. -f1)
             MINOR=$(echo "$LAST_TAG" | sed 's/v//' | cut -d. -f2)
@@ -204,10 +216,11 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.next_version }}"
 
-          git fetch origin main
+          # Fetch both branches so local tracking refs are current after the push above
+          git fetch origin main develop
           git checkout main
-          # Merge the local develop branch (already up-to-date after push above)
-          git merge --no-ff develop -m "chore: release ${VERSION} — merge develop into main"
+          git reset --hard origin/main
+          git merge --no-ff origin/develop -m "chore: release ${VERSION} — merge develop into main"
           git push origin main
 
           echo "develop merged into main for release $VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,216 @@
+name: Release
+
+# Stage 6 — Manual release workflow.
+# Triggered on develop; determines next semver from Conventional Commits,
+# bumps package.json + composer.json, commits to develop, then merges
+# develop → main. The push to main triggers post-merge.yml (CHANGELOG +
+# version tag + GitHub Release) and deploy-prod.yml (PROD deployment).
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump override (auto = determine from commits)'
+        required: false
+        default: 'auto'
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: 'Dry run — show what would happen without pushing'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release (develop → main)
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ secrets.PROJECT_AUTOMATION_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Get commits since last tag
+        id: commits
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          echo "last_tag=$LAST_TAG" >> $GITHUB_OUTPUT
+
+          if [[ -z "$LAST_TAG" ]]; then
+            COMMITS=$(git log --format="%s" -30)
+          else
+            COMMITS=$(git log "${LAST_TAG}..HEAD" --format="%s")
+          fi
+
+          echo "$COMMITS" > /tmp/commits.txt
+          COUNT=$(grep -c '.' /tmp/commits.txt 2>/dev/null || echo "0")
+          echo "count=$COUNT" >> $GITHUB_OUTPUT
+          echo "Commits since ${LAST_TAG:-beginning}: $COUNT"
+          cat /tmp/commits.txt
+
+      - name: Determine next version
+        id: version
+        run: |
+          LAST_TAG="${{ steps.commits.outputs.last_tag }}"
+          COMMITS=$(cat /tmp/commits.txt)
+          OVERRIDE="${{ inputs.bump }}"
+
+          if [[ -z "$LAST_TAG" ]]; then
+            NEXT="v1.0.0"
+          else
+            MAJOR=$(echo "$LAST_TAG" | sed 's/v//' | cut -d. -f1)
+            MINOR=$(echo "$LAST_TAG" | sed 's/v//' | cut -d. -f2)
+            PATCH=$(echo "$LAST_TAG" | sed 's/v//' | cut -d. -f3)
+
+            if [[ "$OVERRIDE" == "major" ]]; then
+              BUMP="major"
+            elif [[ "$OVERRIDE" == "minor" ]]; then
+              BUMP="minor"
+            elif [[ "$OVERRIDE" == "patch" ]]; then
+              BUMP="patch"
+            elif echo "$COMMITS" | grep -qE '(feat|fix|refactor|perf)!:|BREAKING CHANGE'; then
+              BUMP="major"
+            elif echo "$COMMITS" | grep -qE '^feat(\(.+\))?:'; then
+              BUMP="minor"
+            else
+              BUMP="patch"
+            fi
+
+            case "$BUMP" in
+              major) NEXT="v$((MAJOR + 1)).0.0" ;;
+              minor) NEXT="v${MAJOR}.$((MINOR + 1)).0" ;;
+              patch) NEXT="v${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+            esac
+          fi
+
+          echo "next_version=$NEXT" >> $GITHUB_OUTPUT
+          echo "bump_type=$BUMP" >> $GITHUB_OUTPUT
+          echo "Next version: $NEXT (bump: ${BUMP:-initial})"
+
+      - name: Bump package.json version
+        id: bump_npm
+        run: |
+          VERSION="${{ steps.version.outputs.next_version }}"
+          # Strip leading 'v' for package.json
+          VERSION_PLAIN="${VERSION#v}"
+
+          if [[ -f package.json ]]; then
+            # Use node to update version field safely
+            node -e "
+              const fs = require('fs');
+              const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+              pkg.version = '${VERSION_PLAIN}';
+              fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+              console.log('package.json version set to', pkg.version);
+            "
+            echo "npm_bumped=true" >> $GITHUB_OUTPUT
+          else
+            echo "npm_bumped=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Bump composer.json version
+        id: bump_composer
+        run: |
+          VERSION="${{ steps.version.outputs.next_version }}"
+          VERSION_PLAIN="${VERSION#v}"
+
+          if [[ -f composer.json ]]; then
+            node -e "
+              const fs = require('fs');
+              const pkg = JSON.parse(fs.readFileSync('composer.json', 'utf8'));
+              pkg.version = '${VERSION_PLAIN}';
+              fs.writeFileSync('composer.json', JSON.stringify(pkg, null, 2) + '\n');
+              console.log('composer.json version set to', pkg.version);
+            "
+            echo "composer_bumped=true" >> $GITHUB_OUTPUT
+          else
+            echo "composer_bumped=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit version bumps to develop
+        id: bump_commit
+        run: |
+          VERSION="${{ steps.version.outputs.next_version }}"
+
+          git add package.json composer.json 2>/dev/null || true
+          if git diff --staged --quiet; then
+            echo "No version files changed — skipping bump commit."
+            echo "committed=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "chore: bump version to ${VERSION} [skip ci]"
+            echo "committed=true" >> $GITHUB_OUTPUT
+            echo "Committed version bump for $VERSION"
+          fi
+
+      - name: Dry run summary
+        if: inputs.dry_run == true
+        run: |
+          VERSION="${{ steps.version.outputs.next_version }}"
+          LAST_TAG="${{ steps.commits.outputs.last_tag }}"
+          COUNT="${{ steps.commits.outputs.count }}"
+          BUMP="${{ steps.version.outputs.bump_type }}"
+
+          echo "### Dry Run — Release would do the following:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Last tag:** \`${LAST_TAG:-none}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commits since last tag:** $COUNT" >> $GITHUB_STEP_SUMMARY
+          echo "- **Bump type:** $BUMP" >> $GITHUB_STEP_SUMMARY
+          echo "- **Next version:** \`$VERSION\`" >> $GITHUB_STEP_SUMMARY
+          echo "- package.json bumped: ${{ steps.bump_npm.outputs.npm_bumped }}" >> $GITHUB_STEP_SUMMARY
+          echo "- composer.json bumped: ${{ steps.bump_composer.outputs.composer_bumped }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**No changes were pushed** (dry run mode)." >> $GITHUB_STEP_SUMMARY
+
+          # Reset any changes made during dry run
+          git reset --hard HEAD
+          exit 0
+
+      - name: Push version bump to develop
+        if: inputs.dry_run != true && steps.bump_commit.outputs.committed == 'true'
+        run: |
+          git push origin develop
+          echo "Version bump pushed to develop."
+
+      - name: Merge develop into main
+        if: inputs.dry_run != true
+        run: |
+          VERSION="${{ steps.version.outputs.next_version }}"
+
+          git fetch origin main
+          git checkout main
+          git merge --no-ff origin/develop -m "chore: release ${VERSION} — merge develop into main"
+          git push origin main
+
+          echo "develop merged into main for release $VERSION"
+
+      - name: Create release summary
+        if: inputs.dry_run != true
+        run: |
+          VERSION="${{ steps.version.outputs.next_version }}"
+          echo "### Release $VERSION triggered" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- develop merged → main" >> $GITHUB_STEP_SUMMARY
+          echo "- **post-merge.yml** will generate CHANGELOG + git tag + GitHub Release" >> $GITHUB_STEP_SUMMARY
+          echo "- **deploy-prod.yml** will deploy to PROD automatically" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,12 @@ on:
       - feature/*
       - copilot/*
   workflow_call:
+    inputs:
+      ref:
+        description: 'Branch, tag, or SHA to test (default: calling workflow ref)'
+        required: false
+        type: string
+        default: ''
 
 concurrency:
   # For direct branch pushes: cancel previous runs on the same branch.
@@ -33,6 +39,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -84,6 +92,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Summary

- Introduces `develop` branch as the new integration target for feature PRs
- All quality gates (`guard-rails`, `ai-review`, `quality-gate`, `ci`) now run on PRs targeting both `develop` and `main`
- `deploy-dev.yml` now deploys on CI success for `develop` (instead of `main`)
- `deploy-prod.yml` now fires automatically on push to `main` (triggered by `release.yml`) in addition to manual dispatch
- New `release.yml` workflow: manual trigger on `develop`, bumps `package.json` + `composer.json`, merges `develop → main`, which in turn triggers `post-merge.yml` (CHANGELOG + tag + GitHub Release) and `deploy-prod.yml`

## How to test

1. After merging, create the `develop` branch from `main`:
   ```
   git checkout main && git pull
   git checkout -b develop && git push origin develop
   ```
2. Open a feature PR targeting `develop` — all quality checks should trigger
3. Trigger `release.yml` with `dry_run: true` to preview version calculation without pushing

## Notes

- `develop` branch itself is **not created by this PR** — it should be created from `main` immediately after merge so it starts with the updated workflows
- `post-merge.yml` continues to run on `main` pushes (unchanged)
- `deploy-prod.yml` old `workflow_dispatch`-only behaviour is preserved; push-to-`main` is the new automatic path

Closes #486