### PR TITLE
feat: pending migration warning in deploy workflows (#509)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -278,13 +278,18 @@ jobs:
       - name: Check for pending migrations
         if: success()
         run: |
-          MIGRATE_STATUS=$(ssh -o StrictHostKeyChecking=no ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} \
+          MIGRATE_STATUS=$(ssh \
+            -o StrictHostKeyChecking=no \
+            -o BatchMode=yes \
+            -o ConnectTimeout=10 \
+            -o ConnectionAttempts=1 \
+            ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} \
             "cd ${{ secrets.SSH_REMOTE_PATH }} && php artisan migrate:status --no-ansi 2>/dev/null" || echo "MIGRATE_STATUS_FAILED")
 
           if [[ "$MIGRATE_STATUS" == "MIGRATE_STATUS_FAILED" ]]; then
             echo "::warning::Could not determine migration status — check server connectivity."
             echo "PENDING_MIGRATIONS=unknown" >> $GITHUB_ENV
-          elif echo "$MIGRATE_STATUS" | grep -q "^\s*No\b"; then
+          elif echo "$MIGRATE_STATUS" | grep -qE '^\|[[:space:]]*No[[:space:]]*\|'; then
             echo "PENDING_MIGRATIONS=true" >> $GITHUB_ENV
             echo "::warning::Pending migrations detected on DEV. Run manually via SSH: php artisan migrate --force"
           else
@@ -314,8 +319,9 @@ jobs:
             echo "Bitte führe die Migration **manuell per SSH** aus:" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```bash' >> $GITHUB_STEP_SUMMARY
-            echo "ssh ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}" >> $GITHUB_STEP_SUMMARY
-            echo "cd ${{ secrets.SSH_REMOTE_PATH }} && php artisan migrate --force" >> $GITHUB_STEP_SUMMARY
+            echo "# SSH_USERNAME, SSH_HOST and SSH_REMOTE_PATH are stored as GitHub Secrets." >> $GITHUB_STEP_SUMMARY
+            echo "ssh <SSH_USERNAME>@<SSH_HOST>" >> $GITHUB_STEP_SUMMARY
+            echo "cd <SSH_REMOTE_PATH> && php artisan migrate --force" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
           elif [[ "$PENDING_MIGRATIONS" == "unknown" ]]; then
             echo "---" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -275,6 +275,22 @@ jobs:
             echo "✅ Deployment completed successfully!"
           SCRIPT
 
+      - name: Check for pending migrations
+        if: success()
+        run: |
+          MIGRATE_STATUS=$(ssh -o StrictHostKeyChecking=no ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} \
+            "cd ${{ secrets.SSH_REMOTE_PATH }} && php artisan migrate:status --no-ansi 2>/dev/null" || echo "MIGRATE_STATUS_FAILED")
+
+          if [[ "$MIGRATE_STATUS" == "MIGRATE_STATUS_FAILED" ]]; then
+            echo "::warning::Could not determine migration status — check server connectivity."
+            echo "PENDING_MIGRATIONS=unknown" >> $GITHUB_ENV
+          elif echo "$MIGRATE_STATUS" | grep -q "^\s*No\b"; then
+            echo "PENDING_MIGRATIONS=true" >> $GITHUB_ENV
+            echo "::warning::Pending migrations detected on DEV. Run manually via SSH: php artisan migrate --force"
+          else
+            echo "PENDING_MIGRATIONS=false" >> $GITHUB_ENV
+          fi
+
       - name: Create deployment summary
         if: success()
         run: |
@@ -287,6 +303,29 @@ jobs:
           echo "**Author:** ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
           echo "**Message:** ${{ github.event.workflow_run.display_title || github.event.head_commit.message }}" >> $GITHUB_STEP_SUMMARY
           echo "**Zeit:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "$PENDING_MIGRATIONS" == "true" ]]; then
+            echo "---" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### ⚠️ Ausstehende Migrationen!" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Es wurden ausstehende Datenbank-Migrationen erkannt." >> $GITHUB_STEP_SUMMARY
+            echo "Bitte führe die Migration **manuell per SSH** aus:" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```bash' >> $GITHUB_STEP_SUMMARY
+            echo "ssh ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}" >> $GITHUB_STEP_SUMMARY
+            echo "cd ${{ secrets.SSH_REMOTE_PATH }} && php artisan migrate --force" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          elif [[ "$PENDING_MIGRATIONS" == "unknown" ]]; then
+            echo "---" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### ⚠️ Migrationsstatus unbekannt" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Der Migrationsstatus konnte nicht ermittelt werden." >> $GITHUB_STEP_SUMMARY
+            echo "Bitte prüfe manuell ob Migrationen ausstehen." >> $GITHUB_STEP_SUMMARY
+          fi
+
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "🚀 Die Anwendung wurde erfolgreich zur DEV-Umgebung deployed." >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -264,6 +264,22 @@ jobs:
             echo "✅ Deployment completed successfully!"
           SCRIPT
 
+      - name: Check for pending migrations
+        if: success()
+        run: |
+          MIGRATE_STATUS=$(ssh -o StrictHostKeyChecking=no ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} \
+            "cd ${{ secrets.SSH_REMOTE_PATH }} && php artisan migrate:status --no-ansi 2>/dev/null" || echo "MIGRATE_STATUS_FAILED")
+
+          if [[ "$MIGRATE_STATUS" == "MIGRATE_STATUS_FAILED" ]]; then
+            echo "::warning::Could not determine migration status — check server connectivity."
+            echo "PENDING_MIGRATIONS=unknown" >> $GITHUB_ENV
+          elif echo "$MIGRATE_STATUS" | grep -q "^\s*No\b"; then
+            echo "PENDING_MIGRATIONS=true" >> $GITHUB_ENV
+            echo "::warning::Pending migrations detected on PROD. Run manually via SSH: php artisan migrate --force"
+          else
+            echo "PENDING_MIGRATIONS=false" >> $GITHUB_ENV
+          fi
+
       - name: Create deployment summary
         if: success()
         run: |
@@ -276,6 +292,29 @@ jobs:
           echo "**Author:** ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
           echo "**Message:** ${{ github.event.head_commit.message }}" >> $GITHUB_STEP_SUMMARY
           echo "**Zeit:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "$PENDING_MIGRATIONS" == "true" ]]; then
+            echo "---" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### ⚠️ Ausstehende Migrationen!" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Es wurden ausstehende Datenbank-Migrationen erkannt." >> $GITHUB_STEP_SUMMARY
+            echo "Bitte führe die Migration **manuell per SSH** aus:" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```bash' >> $GITHUB_STEP_SUMMARY
+            echo "ssh ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}" >> $GITHUB_STEP_SUMMARY
+            echo "cd ${{ secrets.SSH_REMOTE_PATH }} && php artisan migrate --force" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          elif [[ "$PENDING_MIGRATIONS" == "unknown" ]]; then
+            echo "---" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### ⚠️ Migrationsstatus unbekannt" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Der Migrationsstatus konnte nicht ermittelt werden." >> $GITHUB_STEP_SUMMARY
+            echo "Bitte prüfe manuell ob Migrationen ausstehen." >> $GITHUB_STEP_SUMMARY
+          fi
+
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "🚀 Die Anwendung wurde erfolgreich zur PROD-Umgebung deployed." >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -267,13 +267,18 @@ jobs:
       - name: Check for pending migrations
         if: success()
         run: |
-          MIGRATE_STATUS=$(ssh -o StrictHostKeyChecking=no ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} \
+          MIGRATE_STATUS=$(ssh \
+            -o StrictHostKeyChecking=no \
+            -o BatchMode=yes \
+            -o ConnectTimeout=10 \
+            -o ConnectionAttempts=1 \
+            ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} \
             "cd ${{ secrets.SSH_REMOTE_PATH }} && php artisan migrate:status --no-ansi 2>/dev/null" || echo "MIGRATE_STATUS_FAILED")
 
           if [[ "$MIGRATE_STATUS" == "MIGRATE_STATUS_FAILED" ]]; then
             echo "::warning::Could not determine migration status — check server connectivity."
             echo "PENDING_MIGRATIONS=unknown" >> $GITHUB_ENV
-          elif echo "$MIGRATE_STATUS" | grep -q "^\s*No\b"; then
+          elif echo "$MIGRATE_STATUS" | grep -qE '^\|[[:space:]]*No[[:space:]]*\|'; then
             echo "PENDING_MIGRATIONS=true" >> $GITHUB_ENV
             echo "::warning::Pending migrations detected on PROD. Run manually via SSH: php artisan migrate --force"
           else
@@ -303,8 +308,9 @@ jobs:
             echo "Bitte führe die Migration **manuell per SSH** aus:" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo '```bash' >> $GITHUB_STEP_SUMMARY
-            echo "ssh ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}" >> $GITHUB_STEP_SUMMARY
-            echo "cd ${{ secrets.SSH_REMOTE_PATH }} && php artisan migrate --force" >> $GITHUB_STEP_SUMMARY
+            echo "# SSH_USERNAME, SSH_HOST and SSH_REMOTE_PATH are stored as GitHub Secrets." >> $GITHUB_STEP_SUMMARY
+            echo "ssh <SSH_USERNAME>@<SSH_HOST>" >> $GITHUB_STEP_SUMMARY
+            echo "cd <SSH_REMOTE_PATH> && php artisan migrate --force" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
           elif [[ "$PENDING_MIGRATIONS" == "unknown" ]]; then
             echo "---" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- After each successful deployment, SSH into the server and run `php artisan migrate:status`
- If pending migrations are detected, emit a `::warning::` annotation and a prominent Step Summary block containing the exact SSH command to run manually
- Handles the `MIGRATE_STATUS_FAILED` case (SSH/connectivity issue) separately with an "unknown status" warning
- `php artisan migrate --force` remains intentionally commented out (shared hosting — no atomic rollback)
- Applies to both `deploy-dev.yml` and `deploy-prod.yml`

## How to test

Trigger a manual workflow dispatch on either deploy workflow. With no pending migrations the summary shows only the standard success block. With pending migrations, a `⚠️ Ausstehende Migrationen!` section appears with the exact SSH command.

Closes #509