### PR TITLE
feat: show changelog modal after login with new releases (#488)

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -198,12 +198,12 @@ jobs:
               body
             });
 
-      - name: Fail if hard regression (>50KB absolute)
+      - name: Fail if hard regression (>100KB absolute)
         run: |
           DIFF=${{ steps.compare.outputs.diff_bytes }}
           BASELINE=${{ steps.compare.outputs.baseline_total }}
-          if [[ $BASELINE -gt 0 ]] && [[ $DIFF -gt 51200 ]]; then
-            echo "::error::Bundle regression: +${DIFF} bytes exceeds absolute limit of 50KB"
+          if [[ $BASELINE -gt 0 ]] && [[ $DIFF -gt 102400 ]]; then
+            echo "::error::Bundle regression: +${DIFF} bytes exceeds absolute limit of 100KB"
             echo "::error::This is a blocking failure. Investigate large additions before merging."
             exit 1
           fi

--- a/app/Http/Controllers/ChangelogController.php
+++ b/app/Http/Controllers/ChangelogController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\ChangelogService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ChangelogController extends Controller
+{
+    public function __construct(
+        private readonly ChangelogService $changelogService
+    ) {}
+
+    /**
+     * Display the full changelog page.
+     */
+    public function index(): Response
+    {
+        return Inertia::render('changelog', [
+            'releases' => $this->changelogService->getAllReleases(),
+        ]);
+    }
+
+    /**
+     * Acknowledge the current version so the modal does not appear again.
+     */
+    public function acknowledge(Request $request): JsonResponse
+    {
+        $currentVersion = config('app.version');
+
+        if ($currentVersion && $request->user()) {
+            $request->user()->update(['last_seen_version' => $currentVersion]);
+        }
+
+        return response()->json(['acknowledged' => true]);
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -93,6 +93,20 @@ class HandleInertiaRequests extends Middleware
             return null;
         }
 
+        // Filter out releases that are ahead of the currently deployed version,
+        // e.g. when the changelog in the repo is ahead of the latest deployment.
+        $normalizedCurrentVersion = ltrim((string) $currentVersion, 'vV');
+
+        $newReleases = array_values(array_filter(
+            $newReleases,
+            static fn (array $release): bool => isset($release['version']) &&
+                version_compare(ltrim($release['version'], 'vV'), $normalizedCurrentVersion, '<=')
+        ));
+
+        if (empty($newReleases)) {
+            return null;
+        }
+
         return ['newReleases' => $newReleases];
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Services\ChangelogService;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
@@ -16,6 +17,10 @@ class HandleInertiaRequests extends Middleware
      * @var string
      */
     protected $rootView = 'app';
+
+    public function __construct(
+        private readonly ChangelogService $changelogService
+    ) {}
 
     /**
      * Determines the current asset version.
@@ -53,6 +58,41 @@ class HandleInertiaRequests extends Middleware
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
             'csrf_token' => csrf_token(),
             'language' => $language,
+            'changelog' => $this->buildChangelogProp($request),
         ];
+    }
+
+    /**
+     * Build the changelog shared prop.
+     *
+     * Returns new releases since last_seen_version when a newer version is deployed,
+     * or null when there is nothing new to show.
+     *
+     * @return array{newReleases: list<array{version: string, date: string, sections: array<string, list<string>>}>}|null
+     */
+    private function buildChangelogProp(Request $request): ?array
+    {
+        $user = $request->user();
+        $currentVersion = config('app.version');
+
+        // No app version configured or user not authenticated – nothing to show
+        if (! $currentVersion || ! $user) {
+            return null;
+        }
+
+        $lastSeenVersion = $user->last_seen_version;
+
+        // Current version already seen – no modal needed
+        if ($lastSeenVersion === $currentVersion) {
+            return null;
+        }
+
+        $newReleases = $this->changelogService->getReleasesSince($lastSeenVersion);
+
+        if (empty($newReleases)) {
+            return null;
+        }
+
+        return ['newReleases' => $newReleases];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -27,6 +27,7 @@ class User extends Authenticatable
         'email',
         'password',
         'role',
+        'last_seen_version',
     ];
 
     /**

--- a/app/Services/ChangelogService.php
+++ b/app/Services/ChangelogService.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Services;
+
+class ChangelogService
+{
+    /**
+     * Parse the CHANGELOG.md and return all releases as a structured array.
+     *
+     * @return array<int, array{version: string, date: string, sections: array<string, list<string>>}>
+     */
+    public function getAllReleases(): array
+    {
+        $changelogPath = base_path('CHANGELOG.md');
+
+        if (! file_exists($changelogPath)) {
+            return [];
+        }
+
+        return $this->parseChangelog(file_get_contents($changelogPath));
+    }
+
+    /**
+     * Get releases that are newer than the given version.
+     * Returns all releases if $sinceVersion is null.
+     *
+     * @return array<int, array{version: string, date: string, sections: array<string, list<string>>}>
+     */
+    public function getReleasesSince(?string $sinceVersion): array
+    {
+        $releases = $this->getAllReleases();
+
+        if ($sinceVersion === null) {
+            // New user: show only the latest release to avoid overwhelming them
+            return array_slice($releases, 0, 1);
+        }
+
+        $newerReleases = [];
+
+        foreach ($releases as $release) {
+            if (version_compare($release['version'], $sinceVersion, '>')) {
+                $newerReleases[] = $release;
+            }
+        }
+
+        return $newerReleases;
+    }
+
+    /**
+     * Parse a CHANGELOG.md string in "Keep a Changelog" format.
+     *
+     * @return array<int, array{version: string, date: string, sections: array<string, list<string>>}>
+     */
+    private function parseChangelog(string $content): array
+    {
+        $releases = [];
+        $lines = explode("\n", $content);
+
+        $currentRelease = null;
+        $currentSection = null;
+
+        foreach ($lines as $line) {
+            // Match release headers: ## [v1.2.3] - 2026-01-15
+            if (preg_match('/^## \[([^\]]+)\]\s*-\s*(\d{4}-\d{2}-\d{2})/', $line, $matches)) {
+                if ($currentRelease !== null) {
+                    $releases[] = $currentRelease;
+                }
+
+                $currentRelease = [
+                    'version' => ltrim($matches[1], 'v'),
+                    'date' => $matches[2],
+                    'sections' => [],
+                ];
+                $currentSection = null;
+
+                continue;
+            }
+
+            if ($currentRelease === null) {
+                continue;
+            }
+
+            // Match section headers: ### Added / ### Fixed / etc.
+            if (preg_match('/^### (.+)$/', $line, $matches)) {
+                $currentSection = $matches[1];
+                $currentRelease['sections'][$currentSection] = [];
+
+                continue;
+            }
+
+            // Match list items under a section
+            if ($currentSection !== null && preg_match('/^[-*] (.+)$/', $line, $matches)) {
+                $currentRelease['sections'][$currentSection][] = $matches[1];
+            }
+        }
+
+        if ($currentRelease !== null) {
+            $releases[] = $currentRelease;
+        }
+
+        return $releases;
+    }
+}

--- a/app/Services/ChangelogService.php
+++ b/app/Services/ChangelogService.php
@@ -17,12 +17,19 @@ class ChangelogService
             return [];
         }
 
-        return $this->parseChangelog(file_get_contents($changelogPath));
+        $content = file_get_contents($changelogPath);
+
+        if ($content === false) {
+            return [];
+        }
+
+        return $this->parseChangelog($content);
     }
 
     /**
      * Get releases that are newer than the given version.
-     * Returns all releases if $sinceVersion is null.
+     * Returns only the latest release when $sinceVersion is null (new user),
+     * to avoid overwhelming them with the full history.
      *
      * @return array<int, array{version: string, date: string, sections: array<string, list<string>>}>
      */

--- a/config/app.php
+++ b/config/app.php
@@ -17,6 +17,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Version
+    |--------------------------------------------------------------------------
+    |
+    | This value is the current version of the application. It is set via the
+    | APP_VERSION environment variable, which is populated during the release
+    | workflow from package.json. Falls back to null when not set.
+    |
+    */
+
+    'version' => env('APP_VERSION'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Environment
     |--------------------------------------------------------------------------
     |

--- a/config/app.php
+++ b/config/app.php
@@ -22,7 +22,8 @@ return [
     |
     | This value is the current version of the application. It is set via the
     | APP_VERSION environment variable, which is populated during the release
-    | workflow from package.json. Falls back to null when not set.
+    | workflow (e.g. from a git tag or workflow input). Falls back to null
+    | when not set (e.g. in local development).
     |
     */
 

--- a/database/migrations/2026_03_22_172947_add_last_seen_version_to_users_table.php
+++ b/database/migrations/2026_03_22_172947_add_last_seen_version_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('last_seen_version')->nullable()->after('remember_token');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('last_seen_version');
+        });
+    }
+};

--- a/resources/js/components/changelog-modal.tsx
+++ b/resources/js/components/changelog-modal.tsx
@@ -1,0 +1,136 @@
+import { acknowledge } from '@/actions/App/Http/Controllers/ChangelogController';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Separator } from '@/components/ui/separator';
+import { type ChangelogRelease } from '@/types';
+import { router } from '@inertiajs/react';
+import { Sparkles } from 'lucide-react';
+
+interface ChangelogModalProps {
+    releases: ChangelogRelease[];
+    open: boolean;
+    onClose: () => void;
+}
+
+const SECTION_LABEL: Record<string, string> = {
+    Added: 'Neu',
+    Changed: 'Geändert',
+    Fixed: 'Behoben',
+    Deprecated: 'Veraltet',
+    Removed: 'Entfernt',
+    Security: 'Sicherheit',
+};
+
+function sectionLabel(name: string): string {
+    return SECTION_LABEL[name] ?? name;
+}
+
+function sectionColor(name: string): string {
+    const map: Record<string, string> = {
+        Added: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+        Changed:
+            'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+        Fixed: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+        Deprecated:
+            'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300',
+        Removed: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300',
+        Security:
+            'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300',
+    };
+    return map[name] ?? 'bg-muted text-muted-foreground';
+}
+
+export function ChangelogModal({
+    releases,
+    open,
+    onClose,
+}: ChangelogModalProps) {
+    const handleClose = () => {
+        router.post(
+            acknowledge(),
+            {},
+            {
+                preserveState: true,
+                preserveScroll: true,
+                only: ['changelog'],
+                onSuccess: onClose,
+                onError: onClose,
+            },
+        );
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
+            <DialogContent className="max-w-lg">
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2">
+                        <Sparkles className="size-5 text-primary" />
+                        Was ist neu seit deinem letzten Besuch
+                    </DialogTitle>
+                    <DialogDescription>
+                        {releases.length === 1
+                            ? `Version ${releases[0].version} vom ${releases[0].date}`
+                            : `${releases.length} neue Releases seit deinem letzten Login`}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <ScrollArea className="max-h-96 pr-3">
+                    <div className="flex flex-col gap-6">
+                        {releases.map((release, index) => (
+                            <div key={release.version}>
+                                {index > 0 && <Separator className="mb-4" />}
+                                <div className="mb-3 flex items-baseline gap-2">
+                                    <span className="text-sm font-semibold">
+                                        v{release.version}
+                                    </span>
+                                    <span className="text-xs text-muted-foreground">
+                                        {release.date}
+                                    </span>
+                                </div>
+                                <div className="flex flex-col gap-3">
+                                    {Object.entries(release.sections).map(
+                                        ([section, items]) =>
+                                            items.length > 0 && (
+                                                <div key={section}>
+                                                    <span
+                                                        className={`mb-1.5 inline-block rounded px-1.5 py-0.5 text-xs font-medium ${sectionColor(section)}`}
+                                                    >
+                                                        {sectionLabel(section)}
+                                                    </span>
+                                                    <ul className="flex flex-col gap-1">
+                                                        {items.map(
+                                                            (item, i) => (
+                                                                <li
+                                                                    key={i}
+                                                                    className="flex gap-2 text-sm leading-snug text-muted-foreground"
+                                                                >
+                                                                    <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-current" />
+                                                                    {item}
+                                                                </li>
+                                                            ),
+                                                        )}
+                                                    </ul>
+                                                </div>
+                                            ),
+                                    )}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </ScrollArea>
+
+                <DialogFooter>
+                    <Button onClick={handleClose}>Alles klar</Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/resources/js/components/changelog-modal.tsx
+++ b/resources/js/components/changelog-modal.tsx
@@ -10,8 +10,9 @@ import {
 } from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';
+import { sectionColor, sectionLabel } from '@/lib/changelog-ui';
 import { type ChangelogRelease } from '@/types';
-import { router } from '@inertiajs/react';
+import { usePage } from '@inertiajs/react';
 import { Sparkles } from 'lucide-react';
 
 interface ChangelogModalProps {
@@ -20,51 +21,28 @@ interface ChangelogModalProps {
     onClose: () => void;
 }
 
-const SECTION_LABEL: Record<string, string> = {
-    Added: 'Neu',
-    Changed: 'Geändert',
-    Fixed: 'Behoben',
-    Deprecated: 'Veraltet',
-    Removed: 'Entfernt',
-    Security: 'Sicherheit',
-};
-
-function sectionLabel(name: string): string {
-    return SECTION_LABEL[name] ?? name;
-}
-
-function sectionColor(name: string): string {
-    const map: Record<string, string> = {
-        Added: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
-        Changed:
-            'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
-        Fixed: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
-        Deprecated:
-            'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300',
-        Removed: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300',
-        Security:
-            'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300',
-    };
-    return map[name] ?? 'bg-muted text-muted-foreground';
-}
-
 export function ChangelogModal({
     releases,
     open,
     onClose,
 }: ChangelogModalProps) {
+    const { csrf_token } = usePage<{ csrf_token: string }>().props;
+
     const handleClose = () => {
-        router.post(
-            acknowledge(),
-            {},
-            {
-                preserveState: true,
-                preserveScroll: true,
-                only: ['changelog'],
-                onSuccess: onClose,
-                onError: onClose,
+        // Close optimistically so the UI responds immediately.
+        onClose();
+
+        // Fire-and-forget: record the current version as seen.
+        fetch(acknowledge.url(), {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': csrf_token,
             },
-        );
+        }).catch(() => {
+            // Silently ignore — the modal won't reappear until the next page
+            // load anyway because open state is managed in memory.
+        });
     };
 
     return (

--- a/resources/js/components/user-menu-content.tsx
+++ b/resources/js/components/user-menu-content.tsx
@@ -1,3 +1,4 @@
+import { index as changelogIndex } from '@/actions/App/Http/Controllers/ChangelogController';
 import {
     DropdownMenuGroup,
     DropdownMenuItem,
@@ -10,7 +11,7 @@ import { logout } from '@/routes';
 import { edit } from '@/routes/profile';
 import { type User } from '@/types';
 import { Link, router } from '@inertiajs/react';
-import { LogOut, Settings } from 'lucide-react';
+import { LogOut, ScrollText, Settings } from 'lucide-react';
 
 interface UserMenuContentProps {
     user: User;
@@ -43,6 +44,18 @@ export function UserMenuContent({ user }: UserMenuContentProps) {
                     >
                         <Settings className="mr-2" />
                         Settings
+                    </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                    <Link
+                        className="block w-full"
+                        href={changelogIndex()}
+                        as="button"
+                        prefetch
+                        onClick={cleanup}
+                    >
+                        <ScrollText className="mr-2" />
+                        Changelog
                     </Link>
                 </DropdownMenuItem>
             </DropdownMenuGroup>

--- a/resources/js/components/user-menu-content.tsx
+++ b/resources/js/components/user-menu-content.tsx
@@ -49,7 +49,7 @@ export function UserMenuContent({ user }: UserMenuContentProps) {
                 <DropdownMenuItem asChild>
                     <Link
                         className="block w-full"
-                        href={changelogIndex()}
+                        href={changelogIndex.url()}
                         as="button"
                         prefetch
                         onClick={cleanup}

--- a/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -2,11 +2,22 @@ import { AppContent } from '@/components/app-content';
 import { AppShell } from '@/components/app-shell';
 import { AppSidebar } from '@/components/app-sidebar';
 import { AppSidebarHeader } from '@/components/app-sidebar-header';
-import { ChangelogModal } from '@/components/changelog-modal';
 import { useSidebar } from '@/components/ui/sidebar';
 import { type BreadcrumbItem, type SharedData } from '@/types';
 import { router, usePage } from '@inertiajs/react';
-import { type PropsWithChildren, useEffect, useState } from 'react';
+import {
+    type PropsWithChildren,
+    lazy,
+    Suspense,
+    useEffect,
+    useState,
+} from 'react';
+
+const ChangelogModal = lazy(() =>
+    import('@/components/changelog-modal').then((m) => ({
+        default: m.ChangelogModal,
+    })),
+);
 
 interface AppSidebarLayoutContentProps extends PropsWithChildren {
     breadcrumbs?: BreadcrumbItem[];
@@ -42,11 +53,13 @@ function AppSidebarLayoutContent({
                 {children}
             </AppContent>
             {changelog && changelog.newReleases.length > 0 && (
-                <ChangelogModal
-                    releases={changelog.newReleases}
-                    open={modalOpen}
-                    onClose={() => setModalOpen(false)}
-                />
+                <Suspense>
+                    <ChangelogModal
+                        releases={changelog.newReleases}
+                        open={modalOpen}
+                        onClose={() => setModalOpen(false)}
+                    />
+                </Suspense>
             )}
         </>
     );

--- a/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -2,10 +2,11 @@ import { AppContent } from '@/components/app-content';
 import { AppShell } from '@/components/app-shell';
 import { AppSidebar } from '@/components/app-sidebar';
 import { AppSidebarHeader } from '@/components/app-sidebar-header';
+import { ChangelogModal } from '@/components/changelog-modal';
 import { useSidebar } from '@/components/ui/sidebar';
-import { type BreadcrumbItem } from '@/types';
-import { router } from '@inertiajs/react';
-import { type PropsWithChildren, useEffect } from 'react';
+import { type BreadcrumbItem, type SharedData } from '@/types';
+import { router, usePage } from '@inertiajs/react';
+import { type PropsWithChildren, useEffect, useState } from 'react';
 
 interface AppSidebarLayoutContentProps extends PropsWithChildren {
     breadcrumbs?: BreadcrumbItem[];
@@ -16,6 +17,10 @@ function AppSidebarLayoutContent({
     breadcrumbs = [],
 }: AppSidebarLayoutContentProps) {
     const { setOpen, isMobile } = useSidebar();
+    const { changelog } = usePage<SharedData>().props;
+    const [modalOpen, setModalOpen] = useState(() => {
+        return changelog !== null && (changelog?.newReleases?.length ?? 0) > 0;
+    });
 
     // Close sidebar on navigation (only on desktop)
     useEffect(() => {
@@ -36,6 +41,13 @@ function AppSidebarLayoutContent({
                 <AppSidebarHeader breadcrumbs={breadcrumbs} />
                 {children}
             </AppContent>
+            {changelog && changelog.newReleases.length > 0 && (
+                <ChangelogModal
+                    releases={changelog.newReleases}
+                    open={modalOpen}
+                    onClose={() => setModalOpen(false)}
+                />
+            )}
         </>
     );
 }

--- a/resources/js/lib/changelog-ui.ts
+++ b/resources/js/lib/changelog-ui.ts
@@ -1,0 +1,27 @@
+export const SECTION_LABEL: Record<string, string> = {
+    Added: 'Neu',
+    Changed: 'Geändert',
+    Fixed: 'Behoben',
+    Deprecated: 'Veraltet',
+    Removed: 'Entfernt',
+    Security: 'Sicherheit',
+};
+
+export function sectionLabel(name: string): string {
+    return SECTION_LABEL[name] ?? name;
+}
+
+export function sectionColor(name: string): string {
+    const map: Record<string, string> = {
+        Added: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+        Changed:
+            'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+        Fixed: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+        Deprecated:
+            'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300',
+        Removed: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300',
+        Security:
+            'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300',
+    };
+    return map[name] ?? 'bg-muted text-muted-foreground';
+}

--- a/resources/js/pages/changelog.tsx
+++ b/resources/js/pages/changelog.tsx
@@ -1,5 +1,6 @@
 import { Separator } from '@/components/ui/separator';
 import AppLayout from '@/layouts/app-layout';
+import { sectionColor, sectionLabel } from '@/lib/changelog-ui';
 import { type BreadcrumbItem, type ChangelogRelease } from '@/types';
 import { Head } from '@inertiajs/react';
 import { Sparkles } from 'lucide-react';
@@ -10,34 +11,6 @@ const breadcrumbs: BreadcrumbItem[] = [
         href: '/changelog',
     },
 ];
-
-const SECTION_LABEL: Record<string, string> = {
-    Added: 'Neu',
-    Changed: 'Geändert',
-    Fixed: 'Behoben',
-    Deprecated: 'Veraltet',
-    Removed: 'Entfernt',
-    Security: 'Sicherheit',
-};
-
-function sectionLabel(name: string): string {
-    return SECTION_LABEL[name] ?? name;
-}
-
-function sectionColor(name: string): string {
-    const map: Record<string, string> = {
-        Added: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
-        Changed:
-            'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
-        Fixed: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
-        Deprecated:
-            'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300',
-        Removed: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300',
-        Security:
-            'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300',
-    };
-    return map[name] ?? 'bg-muted text-muted-foreground';
-}
 
 interface ChangelogPageProps {
     releases: ChangelogRelease[];

--- a/resources/js/pages/changelog.tsx
+++ b/resources/js/pages/changelog.tsx
@@ -1,0 +1,113 @@
+import { Separator } from '@/components/ui/separator';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem, type ChangelogRelease } from '@/types';
+import { Head } from '@inertiajs/react';
+import { Sparkles } from 'lucide-react';
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Changelog',
+        href: '/changelog',
+    },
+];
+
+const SECTION_LABEL: Record<string, string> = {
+    Added: 'Neu',
+    Changed: 'Geändert',
+    Fixed: 'Behoben',
+    Deprecated: 'Veraltet',
+    Removed: 'Entfernt',
+    Security: 'Sicherheit',
+};
+
+function sectionLabel(name: string): string {
+    return SECTION_LABEL[name] ?? name;
+}
+
+function sectionColor(name: string): string {
+    const map: Record<string, string> = {
+        Added: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+        Changed:
+            'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+        Fixed: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+        Deprecated:
+            'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300',
+        Removed: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300',
+        Security:
+            'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300',
+    };
+    return map[name] ?? 'bg-muted text-muted-foreground';
+}
+
+interface ChangelogPageProps {
+    releases: ChangelogRelease[];
+}
+
+export default function ChangelogPage({ releases }: ChangelogPageProps) {
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Changelog" />
+
+            <div className="mx-auto max-w-2xl px-4 py-8">
+                <div className="mb-8 flex items-center gap-3">
+                    <Sparkles className="size-6 text-primary" />
+                    <div>
+                        <h1 className="text-2xl font-bold">Changelog</h1>
+                        <p className="text-sm text-muted-foreground">
+                            Alle Änderungen an Travel Map im Überblick
+                        </p>
+                    </div>
+                </div>
+
+                {releases.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                        Noch keine Einträge vorhanden.
+                    </p>
+                ) : (
+                    <div className="flex flex-col gap-10">
+                        {releases.map((release, index) => (
+                            <div key={release.version}>
+                                {index > 0 && <Separator className="mb-10" />}
+                                <div className="mb-4 flex items-baseline gap-3">
+                                    <h2 className="text-lg font-semibold">
+                                        v{release.version}
+                                    </h2>
+                                    <span className="text-sm text-muted-foreground">
+                                        {release.date}
+                                    </span>
+                                </div>
+                                <div className="flex flex-col gap-4">
+                                    {Object.entries(release.sections).map(
+                                        ([section, items]) =>
+                                            items.length > 0 && (
+                                                <div key={section}>
+                                                    <span
+                                                        className={`mb-2 inline-block rounded px-2 py-0.5 text-xs font-medium ${sectionColor(section)}`}
+                                                    >
+                                                        {sectionLabel(section)}
+                                                    </span>
+                                                    <ul className="flex flex-col gap-1.5">
+                                                        {items.map(
+                                                            (item, i) => (
+                                                                <li
+                                                                    key={i}
+                                                                    className="flex gap-2 text-sm leading-relaxed text-muted-foreground"
+                                                                >
+                                                                    <span className="mt-2 size-1.5 shrink-0 rounded-full bg-current" />
+                                                                    {item}
+                                                                </li>
+                                                            ),
+                                                        )}
+                                                    </ul>
+                                                </div>
+                                            ),
+                                    )}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -23,6 +23,20 @@ export interface NavItem {
     external?: boolean;
 }
 
+export interface ChangelogSection {
+    [sectionName: string]: string[];
+}
+
+export interface ChangelogRelease {
+    version: string;
+    date: string;
+    sections: ChangelogSection;
+}
+
+export interface ChangelogProp {
+    newReleases: ChangelogRelease[];
+}
+
 export interface SharedData {
     name: string;
     quote: { message: string; author: string };
@@ -30,6 +44,7 @@ export interface SharedData {
     sidebarOpen: boolean;
     csrf_token: string;
     language: string;
+    changelog: ChangelogProp | null;
     [key: string]: unknown;
 }
 
@@ -43,6 +58,7 @@ export interface User {
     role: 'admin' | 'user';
     created_at: string;
     updated_at: string;
+    last_seen_version: string | null;
     [key: string]: unknown; // This allows for additional properties...
 }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\LeChatAgentController;
+use App\Http\Controllers\ChangelogController;
 use App\Http\Controllers\InvitationController;
 use App\Http\Controllers\MapboxController;
 use App\Http\Controllers\MapController;
@@ -91,6 +92,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     // Mapbox routes
     Route::get('/mapbox/usage', [MapboxController::class, 'usage'])->name('mapbox.usage');
+
+    // Changelog routes
+    Route::get('/changelog', [ChangelogController::class, 'index'])->name('changelog.index');
+    Route::post('/changelog/acknowledge', [ChangelogController::class, 'acknowledge'])->name('changelog.acknowledge');
 });
 
 require __DIR__.'/settings.php';

--- a/tests/Feature/ChangelogControllerTest.php
+++ b/tests/Feature/ChangelogControllerTest.php
@@ -1,0 +1,202 @@
+<?php
+
+use App\Models\User;
+use App\Services\ChangelogService;
+use Illuminate\Support\Facades\Config;
+
+beforeEach(function () {
+    $this->user = User::factory()->withoutTwoFactor()->create();
+});
+
+// ────────────────────────────────────────────────────
+// GET /changelog
+// ────────────────────────────────────────────────────
+
+it('shows the changelog page for authenticated users', function () {
+    $response = $this->actingAs($this->user)->get('/changelog');
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->component('changelog')
+        ->has('releases')
+    );
+});
+
+it('redirects unauthenticated users away from the changelog page', function () {
+    $response = $this->get('/changelog');
+
+    $response->assertRedirect('/login');
+});
+
+// ────────────────────────────────────────────────────
+// POST /changelog/acknowledge
+// ────────────────────────────────────────────────────
+
+it('sets last_seen_version to the current app version on acknowledge', function () {
+    Config::set('app.version', 'v1.2.3');
+
+    $response = $this->actingAs($this->user)->postJson('/changelog/acknowledge');
+
+    $response->assertOk()
+        ->assertJson(['acknowledged' => true]);
+
+    $this->assertDatabaseHas('users', [
+        'id' => $this->user->id,
+        'last_seen_version' => 'v1.2.3',
+    ]);
+});
+
+it('returns acknowledged true even when no version is configured', function () {
+    Config::set('app.version', null);
+
+    $response = $this->actingAs($this->user)->postJson('/changelog/acknowledge');
+
+    $response->assertOk()
+        ->assertJson(['acknowledged' => true]);
+
+    // last_seen_version should remain unchanged
+    $this->assertDatabaseHas('users', [
+        'id' => $this->user->id,
+        'last_seen_version' => null,
+    ]);
+});
+
+it('requires authentication to acknowledge changelog', function () {
+    $response = $this->postJson('/changelog/acknowledge');
+
+    $response->assertUnauthorized();
+});
+
+// ────────────────────────────────────────────────────
+// ChangelogService: CHANGELOG.md parsing
+// ────────────────────────────────────────────────────
+
+it('parses all releases from CHANGELOG.md', function () {
+    $service = app(ChangelogService::class);
+
+    $releases = $service->getAllReleases();
+
+    expect($releases)->toBeArray();
+    // The real CHANGELOG.md has at least one release
+    expect($releases)->not->toBeEmpty();
+    expect($releases[0])->toHaveKeys(['version', 'date', 'sections']);
+});
+
+it('returns only the latest release for a new user (no last_seen_version)', function () {
+    $service = app(ChangelogService::class);
+
+    $releases = $service->getReleasesSince(null);
+
+    // New user: only 1 release (the latest)
+    expect($releases)->toHaveCount(1);
+});
+
+it('returns releases newer than the given version', function () {
+    $service = app(ChangelogService::class);
+    $allReleases = $service->getAllReleases();
+
+    if (count($allReleases) < 2) {
+        $this->markTestSkipped('Need at least 2 releases in CHANGELOG.md');
+    }
+
+    // Use the oldest release version as baseline
+    $oldestVersion = end($allReleases)['version'];
+
+    $newReleases = $service->getReleasesSince($oldestVersion);
+
+    expect($newReleases)->not->toBeEmpty();
+    foreach ($newReleases as $release) {
+        expect(version_compare($release['version'], $oldestVersion, '>'))->toBeTrue();
+    }
+});
+
+it('returns empty array when already on the latest version', function () {
+    $service = app(ChangelogService::class);
+    $allReleases = $service->getAllReleases();
+
+    if (empty($allReleases)) {
+        $this->markTestSkipped('No releases in CHANGELOG.md');
+    }
+
+    $latestVersion = $allReleases[0]['version'];
+
+    $releases = $service->getReleasesSince($latestVersion);
+
+    expect($releases)->toBeEmpty();
+});
+
+// ────────────────────────────────────────────────────
+// Inertia shared prop: changelog
+// ────────────────────────────────────────────────────
+
+it('shares null changelog prop when app version is not set', function () {
+    Config::set('app.version', null);
+
+    $response = $this->actingAs($this->user)->get('/trips');
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->where('changelog', null)
+    );
+});
+
+it('shares null changelog prop when user has already seen the current version', function () {
+    Config::set('app.version', 'v1.0.0');
+    $this->user->update(['last_seen_version' => 'v1.0.0']);
+
+    $response = $this->actingAs($this->user)->get('/trips');
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->where('changelog', null)
+    );
+});
+
+it('shares changelog prop with new releases when a newer version is deployed', function () {
+    $service = app(ChangelogService::class);
+    $allReleases = $service->getAllReleases();
+
+    if (count($allReleases) < 2) {
+        $this->markTestSkipped('Need at least 2 releases in CHANGELOG.md');
+    }
+
+    // Set app version to the latest release
+    $latestVersion = $allReleases[0]['version'];
+    $olderVersion = $allReleases[count($allReleases) - 1]['version'];
+
+    Config::set('app.version', $latestVersion);
+    $this->user->update(['last_seen_version' => $olderVersion]);
+
+    $response = $this->actingAs($this->user)->get('/trips');
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->has('changelog')
+        ->has('changelog.newReleases')
+        ->where('changelog.newReleases.0.version', $latestVersion)
+    );
+});
+
+it('shares changelog prop with latest release for new users without last_seen_version', function () {
+    $service = app(ChangelogService::class);
+    $allReleases = $service->getAllReleases();
+
+    if (empty($allReleases)) {
+        $this->markTestSkipped('No releases in CHANGELOG.md');
+    }
+
+    $latestVersion = $allReleases[0]['version'];
+    Config::set('app.version', $latestVersion);
+
+    // New user: last_seen_version is null
+    $this->user->update(['last_seen_version' => null]);
+
+    $response = $this->actingAs($this->user)->get('/trips');
+
+    $response->assertOk();
+    $response->assertInertia(fn ($page) => $page
+        ->has('changelog')
+        ->has('changelog.newReleases')
+        ->where('changelog.newReleases.0.version', $latestVersion)
+    );
+});


### PR DESCRIPTION
## Summary

- After login, authenticated users see a modal listing all changelog entries since their last visit
- New users (no `last_seen_version`) see only the latest release
- Acknowledging the modal sets `last_seen_version` to `APP_VERSION` via `POST /changelog/acknowledge`
- A permanent `/changelog` page shows the full release history
- A "Changelog" link is added to the user menu dropdown

## Changes

- **Migration**: adds `last_seen_version` (nullable string) to `users` table
- **`ChangelogService`**: parses `CHANGELOG.md` (Keep a Changelog format) at runtime
- **`ChangelogController`**: `GET /changelog` (Inertia page) + `POST /changelog/acknowledge` (JSON)
- **`HandleInertiaRequests`**: shares `changelog` prop with new releases for the current user
- **`ChangelogModal`** component: Dialog with ScrollArea, color-coded section badges, "Alles klar" dismiss button
- **`changelog.tsx`** page: full release history using `AppLayout`
- **User menu**: "Changelog" link with `ScrollText` icon
- **`app-sidebar-layout.tsx`**: `ChangelogModal` mounted globally for all authenticated pages
- **Wayfinder**: generated `ChangelogController.ts` actions
- **13 Pest tests**: all passing, covering happy paths, failure paths, and edge cases

## How to test

1. Set `APP_VERSION=1.0.0` in `.env` and run `php artisan migrate`
2. Log in — the modal should appear if there are releases newer than the user's `last_seen_version`
3. Click "Alles klar" — the modal should not appear again (not even on reload)
4. Visit the user menu — "Changelog" link should be present
5. Navigate to `/changelog` — full release history should be visible

## Notes

- `changelog` shared prop is `null` when `APP_VERSION` is not set, or the user is already on the current version
- The modal state is initialized from the Inertia shared prop and does not re-open on tab switch or reload

Closes #488