### PR TITLE
ci: fix ai-review and deploy-dev workflow triggers (#518, #519)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -23,7 +23,7 @@ jobs:
   review-backend:
     name: 'Backend Architect'
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -109,7 +109,7 @@ jobs:
   review-frontend:
     name: 'Frontend Developer'
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -200,7 +200,7 @@ jobs:
   review-security:
     name: 'Security Engineer'
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -299,7 +299,7 @@ jobs:
   review-database:
     name: 'Database Optimizer'
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -383,7 +383,7 @@ jobs:
     name: 'Reality Checker'
     runs-on: ubuntu-latest
     needs: [review-backend, review-frontend, review-security, review-database]
-    if: always() && github.event.pull_request.draft == false
+    if: always() && github.event_name == 'pull_request' && github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -38,7 +38,7 @@ jobs:
     # - workflow_dispatch: tests must succeed → deploy
     if: |
       always() && (
-        github.event.workflow_run.conclusion == 'success' ||
+        (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'develop') ||
         (github.event_name == 'workflow_dispatch' && needs.tests.result == 'success')
       )
     environment: development


### PR DESCRIPTION
## Summary

- **#518 — `ai-review.yml`:** Added `github.event_name == 'pull_request'` guard to all 5 jobs. The workflow was previously triggered by push events (no PR context available), causing `failure` on every push to `develop`.
- **#519 — `deploy-dev.yml`:** Added `github.event.workflow_run.head_branch == 'develop'` guard to the `deploy` job. CI runs on both `main` and `develop`; without this guard the deploy triggered on CI completion on `main` too, causing `startup_failure`.

## Changes

- `.github/workflows/ai-review.yml` — all job `if:` conditions now include `github.event_name == 'pull_request'`
- `.github/workflows/deploy-dev.yml` — `deploy` job `if:` condition now requires `head_branch == 'develop'` for `workflow_run` triggers

## How to test

1. Push a commit to `develop` — `ai-review.yml` should be **skipped** (not failed)
2. Merge something to `main` — `deploy-dev.yml` should be **skipped** (not startup_failure)
3. Open a PR targeting `develop` — `ai-review.yml` should run normally

Closes #518
Closes #519