### PR TITLE
ci: remove checks: write from tests.yml to fix deploy-dev workflow_call

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -226,7 +226,7 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           # Check for hardcoded secret patterns in added lines only
-          ADDED=$(git diff origin/${BASE_REF}...HEAD | grep '^+' | grep -v '^+++')
+          ADDED=$(git diff origin/${BASE_REF}...HEAD | grep '^+' | grep -v '^+++' || true)
           FOUND=0
 
           # Common secret patterns (not template expressions - those are fine)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,9 +91,6 @@ jobs:
     name: Browser Tests
     runs-on: ubuntu-latest
     if: ${{ !inputs.skip_browser_tests }}
-    permissions:
-      checks: write
-      contents: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

GitHub validates job-level `permissions` statically at parse time — even for jobs guarded by `if: skip_browser_tests`. This caused `deploy-dev.yml` to fail with `checks: none` when calling `tests.yml` via `workflow_call` on `workflow_dispatch`.

Removing `checks: write` from the `browser-tests` job in `tests.yml`. The permission is provided by the caller instead — `ci.yml` already passes `checks: write` on its `test` job.

Fixes #519