### PR TITLE
fix(ci): prevent tag collision in post-merge automation

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -362,8 +362,15 @@ jobs:
           git diff --staged --quiet && echo "No changes to commit." || \
             git commit -m "docs: update changelog for ${VERSION} [skip ci]"
 
-          # Create annotated version tag
-          git tag -a "$VERSION" -m "Release ${VERSION}"
+          # Check if tag already exists
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists — skipping tag creation."
+          else
+            # Create annotated version tag
+            git tag -a "$VERSION" -m "Release ${VERSION}"
+            echo "Tag $VERSION created."
+          fi
+
           git push origin HEAD:main --follow-tags
 
           echo "Tagged and pushed: $VERSION"


### PR DESCRIPTION
## Summary
Fixes Post-Merge Automation workflow failures caused by attempting to create version tags that already exist.

Fixes #524

## Problem
The Post-Merge Automation workflow was failing with:
```
fatal: tag 'v1.1.1' already exists
```

This occurred on subsequent runs when the tag was already created in a previous automation run.

**Failed workflow run:** https://github.com/TheRealKoller/travel-map/actions/runs/23555354437

## Solution
Added a conditional check before creating version tags:
- Checks if tag already exists using `git rev-parse`
- Skips tag creation if tag exists
- Creates tag if it doesn't exist
- Logs appropriate message for both scenarios

## Testing
- Manual verification of git tag logic
- Will be verified by next Post-Merge Automation workflow run

## Changes
- `.github/workflows/post-merge.yml`: Added tag existence check (lines 365-373)

## Type
🔥 Hotfix - Production workflow issue requiring immediate attention