### PR TITLE
fix(ci): use GitHub App token in post-merge workflow

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -3,7 +3,8 @@ name: Post-Merge Automation
 # Stage 5 — Runs on every push to main.
 # Agents: Senior Project Manager (close issue, move board card),
 #         Documentation Generator (CHANGELOG + semver version tag).
-# Requires PROJECT_AUTOMATION_TOKEN (PAT with 'project' scope) for board updates.
+# Requires GitHub App credentials (APP_ID + APP_PRIVATE_KEY) to bypass branch protection
+# and write to Projects v2.
 
 on:
   push:
@@ -20,6 +21,13 @@ jobs:
     name: 'Senior Project Manager'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
@@ -28,8 +36,8 @@ jobs:
         id: issues
         uses: actions/github-script@v7
         with:
-          # Use PAT for project board writes — GITHUB_TOKEN cannot write Projects v2
-          github-token: ${{ secrets.PROJECT_AUTOMATION_TOKEN || secrets.GITHUB_TOKEN }}
+          # Use GitHub App token for project board writes
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             // Get the merge commit message
             const commit = await github.rest.repos.getCommit({
@@ -217,10 +225,17 @@ jobs:
     name: 'Documentation Generator'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.PROJECT_AUTOMATION_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Get commits since last tag
         id: commits


### PR DESCRIPTION
## Summary
Replaces PAT-based authentication with GitHub App authentication in the Post-Merge Automation workflow, allowing it to bypass branch protection rules and push changelog commits directly to main.

## Problem
The Post-Merge Automation workflow was failing when trying to push changelog commits to main because:
- Branch protection requires all changes to go through PRs
- GITHUB_TOKEN respects branch protection rules even with write permissions
- Using a PAT with admin rights is a security risk

## Solution
Configured the workflow to use a GitHub App for authentication:
- GitHub App can bypass branch protection with proper permissions
- More secure than PAT (scoped to specific repo and permissions)
- Can be revoked without affecting user account

## Changes
- Added `actions/create-github-app-token@v1` step in both jobs
- Updated checkout and github-script actions to use app token
- Updated workflow comments to reflect new authentication method

## Prerequisites
Repository secrets must be configured:
- `APP_ID`: GitHub App ID
- `APP_PRIVATE_KEY`: GitHub App private key (PEM format)

GitHub App must have permissions:
- Contents: Read and write
- Issues: Read and write
- Pull requests: Read
- Projects: Read and write

## Testing
After merge, the next push to main should successfully:
- Update CHANGELOG.md
- Create version tags
- Close linked issues
- Update project board