### PR TITLE
Fix release workflow GitHub App authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ name: Release
 # bumps package.json + composer.json, commits to develop, then merges
 # develop → main. The push to main triggers post-merge.yml (CHANGELOG +
 # version tag + GitHub Release) and deploy-prod.yml (PROD deployment).
+#
+# IMPORTANT: Uses GitHub App "travel-map-automation" to trigger downstream
+# workflows (GITHUB_TOKEN cannot trigger post-merge.yml or deploy-prod.yml).
+# Requires APP_ID and APP_PRIVATE_KEY secrets configured.
 
 on:
   workflow_dispatch:
@@ -40,23 +44,19 @@ jobs:
     environment: production
 
     steps:
-      - name: Validate automation token
-        env:
-          TOKEN: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
-        run: |
-          if [[ -z "$TOKEN" ]]; then
-            echo "::error::PROJECT_AUTOMATION_TOKEN secret is required."
-            echo "::error::Pushes with GITHUB_TOKEN do not trigger downstream workflows (post-merge.yml, deploy-prod.yml)."
-            echo "::error::Add a PAT with 'contents:write' scope as PROJECT_AUTOMATION_TOKEN in repository secrets."
-            exit 1
-          fi
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout develop
         uses: actions/checkout@v4
         with:
           ref: develop
           fetch-depth: 0
-          token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure git
         run: |


### PR DESCRIPTION
## Summary

Fixes #529

Replaces the PAT-based authentication in the release workflow with GitHub App authentication to enable downstream workflow triggers.

## Changes

- Removed `PROJECT_AUTOMATION_TOKEN` validation step
- Added GitHub App token generation using `actions/create-github-app-token@v1`
- Updated checkout step to use app token
- Added documentation comment about GitHub App requirement

## Why

The release workflow was failing because:
- It required `PROJECT_AUTOMATION_TOKEN` secret which wasn't configured
- Pushes with `GITHUB_TOKEN` don't trigger downstream workflows (`post-merge.yml`, `deploy-prod.yml`)
- GitHub App tokens trigger downstream workflows while being more secure than PATs

## Testing

- [ ] Trigger release workflow manually
- [ ] Verify downstream workflows (post-merge.yml, deploy-prod.yml) are triggered